### PR TITLE
Solve missing quantum.h on WS2812 driver for AVR

### DIFF
--- a/drivers/avr/ws2812.c
+++ b/drivers/avr/ws2812.c
@@ -20,6 +20,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+#include "quantum.h"
 #include "ws2812.h"
 #include <avr/interrupt.h>
 #include <avr/io.h>


### PR DESCRIPTION
Solve missing quantum.h on WS2812 driver for AVR mC