### PR TITLE
Solve missing stdint.h on I2C driver for AVR

### DIFF
--- a/drivers/avr/i2c_master.h
+++ b/drivers/avr/i2c_master.h
@@ -18,6 +18,7 @@
  */
 
 #pragma once
+#include <stdint.h>
 
 #define I2C_READ 0x01
 #define I2C_WRITE 0x00


### PR DESCRIPTION
Solve missing stdint.h on I2C driver for AVR