### PR TITLE
Solve missing stdint.h on OLED driver

### DIFF
--- a/drivers/oled/oled_driver.c
+++ b/drivers/oled/oled_driver.c
@@ -21,6 +21,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "print.h"
 
 #include <string.h>
+#include <stdint.h>
 
 #include "progmem.h"
 


### PR DESCRIPTION
Solve missing stdint.h on OLED driver
