### PR TITLE
Reintroduced matrix tester, but it's disabled by default and requires…

### DIFF
--- a/quantum/via.c
+++ b/quantum/via.c
@@ -256,8 +256,9 @@ void raw_hid_receive(uint8_t *data, uint8_t length) {
                 }
                 case id_switch_matrix_state: {
 #ifdef VIAL_ENABLE
-                    /* We don't need this wannabe keylogger */
-                    goto skip;
+                    /* Disable wannabe keylogger unless unlocked */
+                    if (!vial_unlocked)
+                        goto skip;
 #endif
 
 #if ((MATRIX_COLS / 8 + 1) * MATRIX_ROWS <= 28)

--- a/quantum/vial.h
+++ b/quantum/vial.h
@@ -19,7 +19,7 @@
 #include <inttypes.h>
 #include <stdbool.h>
 
-#define VIAL_PROTOCOL_VERSION ((uint32_t)0x00000002)
+#define VIAL_PROTOCOL_VERSION ((uint32_t)0x00000003)
 
 void vial_handle_cmd(uint8_t *data, uint8_t length);
 


### PR DESCRIPTION
… unlock

Since the matrix test is something I need use a lot, and I like using VIAL.
I've reversed the disabling of the matrix test feature in VIAL and locked it behind the lock feature in VIAL.
I've also increased the VIAL protocol version, so the Gui can distinguish boards that do and don't support the new implementation.
This PR goes in tandem with A PR that implements a tester in the GUI, see: https://github.com/vial-kb/vial-gui/pull/25
In regards to issue: https://github.com/vial-kb/vial-gui/issues/23