### PR TITLE
Update rules.mk

### DIFF
--- a/keyboards/keebio/bdn9/rev2/rules.mk
+++ b/keyboards/keebio/bdn9/rev2/rules.mk
@@ -19,6 +19,7 @@ MIDI_ENABLE = no            # MIDI support
 BLUETOOTH_ENABLE = no       # Enable Bluetooth with the Adafruit EZ-Key HID
 AUDIO_ENABLE = no           # Audio output on port C6
 ENCODER_ENABLE = yes
+VIAL_ENCODERS_ENABLE = yes  # Enable VIAL Encoder
 RGB_MATRIX_ENABLE = yes
 RGB_MATRIX_DRIVER = WS2812
 


### PR DESCRIPTION
This PR enables on the fly rotary encoder support in Vial. Allows users to add Vial encoders as part of their KLE keymap
[Vial Encoder Support](https://get.vial.today/gettingStarted/encoders.html)