### PR TITLE
Port bm16s from via to vial

### DIFF
--- a/keyboards/kprepublic/bm16s/keymaps/vial/config.h
+++ b/keyboards/kprepublic/bm16s/keymaps/vial/config.h
@@ -1,0 +1,8 @@
+/* SPDX-License-Identifier: GPL-2.0-or-later */
+
+#pragma once
+
+#define VIAL_KEYBOARD_UID {0x15, 0xCC, 0x19, 0x23, 0x67, 0xBD, 0xB7, 0x02}
+
+#define VIAL_UNLOCK_COMBO_ROWS { 3, 3 }
+#define VIAL_UNLOCK_COMBO_COLS { 0, 3 }

--- a/keyboards/kprepublic/bm16s/keymaps/vial/keymap.c
+++ b/keyboards/kprepublic/bm16s/keymaps/vial/keymap.c
@@ -1,0 +1,43 @@
+/* Copyright 2020 Relocks
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#include QMK_KEYBOARD_H
+
+const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+	[0] = LAYOUT_ortho_4x4(
+		KC_KP_7, KC_KP_8, KC_KP_9, MO(1),
+		KC_KP_4, KC_KP_5, KC_KP_6, KC_PMNS,
+		KC_KP_1, KC_KP_2, KC_KP_3, KC_PPLS,
+		KC_KP_0, KC_PDOT, KC_PCMM, KC_PENT
+	),
+	[1] = LAYOUT_ortho_4x4(
+		RESET,   BL_STEP, KC_TRNS, KC_VOLU,
+		BL_TOGG, BL_DEC,  BL_INC,  KC_VOLD,
+		RGB_TOG, RGB_MOD, RGB_HUI, KC_MUTE,
+		RGB_SAI, RGB_SAD, RGB_HUD, KC_TRNS
+	),
+	[2] = LAYOUT_ortho_4x4(
+		KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS,
+		KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS,
+		KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS,
+		KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS
+	),
+	[3] = LAYOUT_ortho_4x4(
+		KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS,
+		KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS,
+		KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS,
+		KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS
+	),
+};

--- a/keyboards/kprepublic/bm16s/keymaps/vial/rules.mk
+++ b/keyboards/kprepublic/bm16s/keymaps/vial/rules.mk
@@ -1,0 +1,4 @@
+VIA_ENABLE = yes
+VIAL_ENABLE = yes
+LTO_ENABLE = yes
+COMBO_ENABLE = no

--- a/keyboards/kprepublic/bm16s/keymaps/vial/vial.json
+++ b/keyboards/kprepublic/bm16s/keymaps/vial/vial.json
@@ -1,0 +1,17 @@
+{
+  "name": "KPrepublic bm16-s",
+  "vendorId": "0x4B50",
+  "productId": "0x016b",
+  "firmwareVersion": 0,
+  "keycodes": ["via/keycodes"],
+  "lighting": "qmk_rgblight",
+  "matrix": {"rows": 4, "cols": 4},
+  "layouts": {
+    "keymap": [
+      ["0,0", "0,1", "0,2", "0,3"],
+      ["1,0", "1,1", "1,2", "1,3"],
+      ["2,0", "2,1", "2,2", "2,3"],
+      ["3,0", "3,1", "3,2", "3,3"]
+    ]
+  }
+}


### PR DESCRIPTION
<!---
    For keyboard addition or changes, Vial will accept keyboards that implement "default" and "via" keymaps.
    For Vial-enabled keymaps please ensure that VIAL_INSECURE is not set.

    User keymaps (i.e. https://github.com/vial-kb/vial-qmk/tree/vial/users) will not be accepted at the moment.

    For other core changes, please explain what you are changing and why.

    Before submitting a PR, delete the entirety of this comment and document your changes.
-->
Ported the BM16S to Vial from the existing Via config using [these steps](https://get.vial.today/docs/porting-to-vial.html). Combos were disabled to save firmware space.

<img width="812" alt="Screen Shot 2022-01-11 at 9 40 35 PM" src="https://user-images.githubusercontent.com/3178606/149071660-5525ab49-1496-41e9-b91b-1347f7412593.png">

