### PR TITLE
port keebwerk/nano_slider to via/vial

### DIFF
--- a/keyboards/keebwerk/nano_slider/keymaps/via/keymap.c
+++ b/keyboards/keebwerk/nano_slider/keymaps/via/keymap.c
@@ -1,0 +1,28 @@
+#include QMK_KEYBOARD_H
+#include "analog.h"
+#include "qmk_midi.h"
+
+#define ____ KC_TRNS
+
+const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+    [0] = LAYOUT(
+        TO(1),
+        KC_1,    KC_2,    KC_3,
+        KC_4,    KC_5,    KC_6,    KC_0
+    ),
+    [1] = LAYOUT(
+        TO(2),
+        RGB_MOD, RGB_HUI,  RGB_VAI,
+        RGB_RMOD,  RGB_HUD, RGB_VAD, RGB_TOG
+    ),
+    [2] = LAYOUT(
+        TO(3),
+        KC_VOLD, KC_VOLU, KC_F24,
+        KC_MRWD, KC_MFFD, KC_F23, KC_MPLY
+    ),
+    [3] = LAYOUT(
+        TO(0),
+        ____,    ____,    ____,
+        ____,    ____,    ____,    ____
+    )
+};

--- a/keyboards/keebwerk/nano_slider/keymaps/via/rules.mk
+++ b/keyboards/keebwerk/nano_slider/keymaps/via/rules.mk
@@ -1,0 +1,1 @@
+VIA_ENABLE = yes

--- a/keyboards/keebwerk/nano_slider/keymaps/via/via.json
+++ b/keyboards/keebwerk/nano_slider/keymaps/via/via.json
@@ -1,0 +1,34 @@
+{
+    "name": "Keebwerks Nano Slider",
+    "vendorId": "0x03A8",
+    "productId": "0x0000",
+    "lighting": "none",
+    "matrix": {
+        "rows": 2,
+        "cols": 4
+    },
+    "layouts": {
+        "keymap": [
+            [
+              "1,1"
+            ],
+            [
+              {
+                "y": 0.25
+              },
+              "1,2",
+              "1,0",
+              "0,0",
+              {
+                "h": 2
+              },
+              "1,3"
+            ],
+            [
+              "0,1",
+              "0,2",
+              "0,3"
+            ]
+          ]
+    }
+}

--- a/keyboards/keebwerk/nano_slider/keymaps/vial/config.h
+++ b/keyboards/keebwerk/nano_slider/keymaps/vial/config.h
@@ -1,0 +1,6 @@
+/* SPDX-License-Identifier: GPL-2.0-or-later */
+
+#pragma once
+#define VIAL_KEYBOARD_UID {0x91, 0x02, 0x1F, 0xAA, 0xE1, 0x00, 0x54, 0xC2}
+#define VIAL_UNLOCK_COMBO_ROWS { 1, 1 }
+#define VIAL_UNLOCK_COMBO_COLS { 1, 3 }

--- a/keyboards/keebwerk/nano_slider/keymaps/vial/keymap.c
+++ b/keyboards/keebwerk/nano_slider/keymaps/vial/keymap.c
@@ -1,0 +1,28 @@
+#include QMK_KEYBOARD_H
+#include "analog.h"
+#include "qmk_midi.h"
+
+#define ____ KC_TRNS
+
+const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+    [0] = LAYOUT(
+        TO(1),
+        KC_1,    KC_2,    KC_3,
+        KC_4,    KC_5,    KC_6,    KC_0
+    ),
+    [1] = LAYOUT(
+        TO(2),
+        RGB_MOD, RGB_HUI,  RGB_VAI,
+        RGB_RMOD,  RGB_HUD, RGB_VAD, RGB_TOG
+    ),
+    [2] = LAYOUT(
+        TO(3),
+        KC_VOLD, KC_VOLU, KC_F24,
+        KC_MRWD, KC_MFFD, KC_F23, KC_MPLY
+    ),
+    [3] = LAYOUT(
+        TO(0),
+        ____,    ____,    ____,
+        ____,    ____,    ____,    ____
+    )
+};

--- a/keyboards/keebwerk/nano_slider/keymaps/vial/rules.mk
+++ b/keyboards/keebwerk/nano_slider/keymaps/vial/rules.mk
@@ -1,0 +1,5 @@
+VIA_ENABLE = yes
+VIAL_ENABLE = yes
+LTO_ENABLE = yes
+COMBO_ENABLE = no
+QMK_SETTINGS = no

--- a/keyboards/keebwerk/nano_slider/keymaps/vial/vial.json
+++ b/keyboards/keebwerk/nano_slider/keymaps/vial/vial.json
@@ -1,0 +1,34 @@
+{
+    "name": "Keebwerks Nano Slider",
+    "vendorId": "0x03A8",
+    "productId": "0x0000",
+    "lighting": "none",
+    "matrix": {
+        "rows": 2,
+        "cols": 4
+    },
+    "layouts": {
+        "keymap": [
+            [
+              "1,1"
+            ],
+            [
+              {
+                "y": 0.25
+              },
+              "1,2",
+              "1,0",
+              "0,0",
+              {
+                "h": 2
+              },
+              "1,3"
+            ],
+            [
+              "0,1",
+              "0,2",
+              "0,3"
+            ]
+          ]
+    }
+}


### PR DESCRIPTION
<!---
    For keyboard addition or changes, Vial will accept keyboards that implement "default" and "via" keymaps.
    For Vial-enabled keymaps please ensure that VIAL_INSECURE is not set.

    User keymaps (i.e. https://github.com/vial-kb/vial-qmk/tree/vial/users) will not be accepted at the moment.

    For other core changes, please explain what you are changing and why.

    Before submitting a PR, delete the entirety of this comment and document your changes.
-->
Add new keymap for via and vial.