### PR TITLE
Add configs for TheKeyV2 based on V1

### DIFF
--- a/keyboards/massdrop/thekey_v2/config.h
+++ b/keyboards/massdrop/thekey_v2/config.h
@@ -1,0 +1,61 @@
+/* Copyright 2021 Joe Maples <joe@maples.dev>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "config_common.h"
+
+/* USB Device descriptor parameter */
+#define VENDOR_ID       0x04D8
+#define PRODUCT_ID      0x1337
+#define DEVICE_VER      0x0102
+
+#define MANUFACTURER        "Massdrop Inc."
+#define PRODUCT             "The Key V2"
+#define SERIAL_NUM          "Unavailable"
+
+/* key matrix size */
+#define MATRIX_ROWS 1
+#define MATRIX_COLS 3
+
+/*
+ * Keyboard Matrix Assignments
+ */
+#define MATRIX_ROW_PINS { D4 }
+#define MATRIX_COL_PINS { D2, D1, D0 }
+
+#define DIODE_DIRECTION ROW2COL
+
+#define RGB_DI_PIN B1
+#define RGBLED_NUM 5
+#define RGBLIGHT_HUE_STEP 8
+#define RGBLIGHT_SAT_STEP 8
+#define RGBLIGHT_VAL_STEP 8
+#define RGBLIGHT_LIMIT_VAL 255 /* The maximum brightness level */
+#define RGBLIGHT_SLEEP  /* If defined, the RGB lighting will be switched off when the host goes to sleep */
+#define RGBLIGHT_ANIMATIONS
+
+/* Disable Mechanical locking support. */
+#ifdef LOCKING_SUPPORT_ENABLE
+#define LOCKING_SUPPORT_ENABLE
+#endif
+/* Disable Locking resynchronize hack */
+#ifdef LOCKING_RESYNC_ENABLE
+#undef LOCKING_RESYNC_ENABLE
+#endif
+
+/* Turn off music mode. */
+#define NO_MUSIC_MODE

--- a/keyboards/massdrop/thekey_v2/info.json
+++ b/keyboards/massdrop/thekey_v2/info.json
@@ -1,0 +1,14 @@
+{
+    "keyboard_name": "The Key V2",
+    "url": "https://drop.com/buy/stack-overflow-the-key-v2-macropad/",
+    "maintainer": "MallardDuck",
+    "layouts": {
+        "LAYOUT": {
+            "layout": [
+                { "label": "K00 (D4,D2)", "x": 0, "y": 0 },
+                { "label": "K01 (D4,D1)", "x": 1, "y": 0 },
+                { "label": "K02 (D4,D0)", "x": 2, "y": 0 }
+            ]
+        }
+    }
+}

--- a/keyboards/massdrop/thekey_v2/keymaps/default-macos/keymap.c
+++ b/keyboards/massdrop/thekey_v2/keymaps/default-macos/keymap.c
@@ -1,0 +1,23 @@
+/* Copyright 2021 Joe Maples <joe@maples.dev>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include QMK_KEYBOARD_H
+
+const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+
+    [0] = LAYOUT(KC_LGUI, KC_C, KC_V),
+
+};

--- a/keyboards/massdrop/thekey_v2/keymaps/default/keymap.c
+++ b/keyboards/massdrop/thekey_v2/keymaps/default/keymap.c
@@ -1,0 +1,23 @@
+/* Copyright 2021 Joe Maples <joe@maples.dev>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include QMK_KEYBOARD_H
+
+const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+
+    [0] = LAYOUT(KC_LCTL, KC_C, KC_V),
+
+};

--- a/keyboards/massdrop/thekey_v2/keymaps/url-copy-paste-macos/keymap.c
+++ b/keyboards/massdrop/thekey_v2/keymaps/url-copy-paste-macos/keymap.c
@@ -1,0 +1,39 @@
+/* Copyright 2021 Joe Maples <joe@maples.dev>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include QMK_KEYBOARD_H
+
+enum custom_keycodes {
+    TK_URL = SAFE_RANGE,
+};
+
+const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+    [0] = LAYOUT(TK_URL, G(KC_C), G(KC_V)),
+};
+
+bool process_record_user(uint16_t keycode, keyrecord_t *record) {
+    switch (keycode) {
+        case TK_URL:
+            if (record->event.pressed) {
+                // when keycode TK_URL is pressed
+                SEND_STRING("https://stackoverflow.com/\n");
+            }
+            break;
+        default:
+            break;
+    }
+    return true;
+}

--- a/keyboards/massdrop/thekey_v2/keymaps/url-copy-paste/keymap.c
+++ b/keyboards/massdrop/thekey_v2/keymaps/url-copy-paste/keymap.c
@@ -1,0 +1,40 @@
+/* Copyright 2021 Joe Maples <joe@maples.dev>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include QMK_KEYBOARD_H
+
+enum custom_keycodes {
+    TK_URL = SAFE_RANGE,
+};
+
+const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+    [0] = LAYOUT(TK_URL, C(KC_C), C(KC_V)),
+};
+
+
+bool process_record_user(uint16_t keycode, keyrecord_t *record) {
+    switch (keycode) {
+        case TK_URL:
+            if (record->event.pressed) {
+                // when keycode TK_URL is pressed
+                SEND_STRING("https://stackoverflow.com/");
+            }
+            break;
+        default:
+            break;
+    }
+    return true;
+}

--- a/keyboards/massdrop/thekey_v2/keymaps/vial/config.h
+++ b/keyboards/massdrop/thekey_v2/keymaps/vial/config.h
@@ -1,0 +1,12 @@
+/* SPDX-License-Identifier: GPL-2.0-or-later */
+
+#pragma once
+
+#define VIAL_KEYBOARD_UID {0x5E, 0x62, 0xD5, 0x7B, 0x88, 0xD7, 0x45, 0xA5}
+
+#define VIAL_UNLOCK_COMBO_ROWS { 0, 0 }
+#define VIAL_UNLOCK_COMBO_COLS { 1, 2 }
+
+/* Reduce keymap mem usage by capping to 6 */
+#define LAYER_STATE_8BIT
+#define DYNAMIC_KEYMAP_LAYER_COUNT 6

--- a/keyboards/massdrop/thekey_v2/keymaps/vial/keymap.c
+++ b/keyboards/massdrop/thekey_v2/keymaps/vial/keymap.c
@@ -1,0 +1,53 @@
+/* Copyright 2021 Joe Maples <joe@maples.dev>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include QMK_KEYBOARD_H
+
+enum custom_keycodes {
+    TK_URL = SAFE_RANGE,
+};
+
+enum layer_names {
+    _DEFAULT,
+    _MACOS,
+    _THREE,
+    _FOUR,
+    _FIVE,
+    _SIX
+};
+
+const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+    [_DEFAULT] = LAYOUT(TK_URL, C(KC_C), C(KC_V)),
+    [_MACOS] = LAYOUT(TK_URL, G(KC_C), G(KC_V)),
+    [_THREE] = LAYOUT(KC_LCTL, KC_C, KC_V),
+    [_FOUR] = LAYOUT(KC_TRNS, KC_TRNS, KC_TRNS),
+    [_FIVE] = LAYOUT(KC_TRNS, KC_TRNS, KC_TRNS),
+    [_SIX] = LAYOUT(KC_TRNS, KC_TRNS, KC_TRNS),
+};
+
+bool process_record_user(uint16_t keycode, keyrecord_t *record) {
+    switch (keycode) {
+        case TK_URL:
+            if (record->event.pressed) {
+                // when keycode TK_URL is pressed
+                SEND_STRING("https://stackoverflow.com/\n");
+            }
+            break;
+        default:
+            break;
+    }
+    return true;
+}

--- a/keyboards/massdrop/thekey_v2/keymaps/vial/rules.mk
+++ b/keyboards/massdrop/thekey_v2/keymaps/vial/rules.mk
@@ -1,0 +1,46 @@
+# Processor frequency.
+#     This will define a symbol, F_CPU, in all source code files equal to the
+#     processor frequency in Hz. You can then use this symbol in your source code to
+#     calculate timings. Do NOT tack on a 'UL' at the end, this will be done
+#     automatically to create a 32-bit value in your source code.
+#
+#     This will be an integer division of F_USB below, as it is sourced by
+#     F_USB after it has run through any CPU prescalers. Note that this value
+#     does not *change* the processor frequency - it should merely be updated to
+#     reflect the processor speed set externally so that the code can use accurate
+#     software delays.
+F_CPU = 16000000
+
+# Input clock frequency.
+#     This will define a symbol, F_USB, in all source code files equal to the
+#     input clock frequency (before any prescaling is performed) in Hz. This value may
+#     differ from F_CPU if prescaling is used on the latter, and is required as the
+#     raw input clock is fed directly to the PLL sections of the AVR for high speed
+#     clock generation for the USB and other AVR subsections. Do NOT tack on a 'UL'
+#     at the end, this will be done automatically to create a 32-bit value in your
+#     source code.
+#
+#     If no clock division is performed on the input clock inside the AVR (via the
+#     CPU clock adjust registers or the clock division fuses), this will be equal to F_CPU.
+F_USB = $(F_CPU)
+
+# Interrupt driven control endpoint task(+60)
+OPT_DEFS += -DINTERRUPT_CONTROL_ENDPOINT
+
+# Boot Section Size in *bytes*
+OPT_DEFS += -DBOOTLOADER_SIZE=4096
+
+VIA_ENABLE = yes
+VIAL_ENABLE = yes
+
+CONSOLE_ENABLE = no # Non debug builds should disable console
+SPACE_CADET_ENABLE = no # No need for space-cadet shifts on 3 key macro
+GRAVE_ESC_ENABLE = no # Not a 60% keeb so no need for grave escape
+COMMAND_ENABLE = no # Not enough keys to use command feature
+KEY_OVERRIDE_ENABLE = no # No modifier keys so no need for key override
+QMK_SETTINGS = no
+MOUSEKEY_ENABLE = yes        # Mouse keys
+
+# opts
+LTO_ENABLE = yes
+AVR_USE_MINIMAL_PRINTF = yes

--- a/keyboards/massdrop/thekey_v2/keymaps/vial/vial.json
+++ b/keyboards/massdrop/thekey_v2/keymaps/vial/vial.json
@@ -1,0 +1,12 @@
+{
+  "lighting": "qmk_backlight_rgblight",
+  "matrix": {
+    "rows": 1,
+    "cols": 3
+  },
+  "layouts": {
+    "keymap": [
+      [ "0,0", "0,1", "0,2" ]
+    ]
+  }
+}

--- a/keyboards/massdrop/thekey_v2/readme.md
+++ b/keyboards/massdrop/thekey_v2/readme.md
@@ -1,0 +1,38 @@
+# The Key
+
+![The Key](https://i.imgur.com/hL5cRj9.jpg)
+
+
+The Stack Overflow "The Key" is a 3 button macropad based on atmega32u4 with Kailh Black Box switches.
+
+> Some say a programmer’s best solution is a simple two-step process: copy and paste. On April 1st, 2021, Stack Overflow proved it. On that fateful day, each time users went to copy a piece of code, they were met with a pop-up for a fake product. It was called The Key: an ultra-compact macropad advertised as the new (and only) way to copy and paste on the platform. As it turns out, roughly one fourth of Stack Overflow’s 15 million users tries to copy and paste within five minutes of visiting the site. An even greater number saw the joke and loved it, with many demanding that The Key be developed in earnest. So, naturally, we teamed up with Stack Overflow to make it happen. What started as an April Fool’s gag is now a full-fledged macropad—designed by our very own community member Cassidy, with a portion of proceeds benefiting digitalundivided.
+
+Keyboard Maintainer: [Drop / Massdrop](https://github.com/Massdrop/qmk_firmware) 
+
+Hardware Supported: Massdrop, Inc. **The Key**
+
+Hardware Availability: Limited Release - https://drop.com/buy/stack-overflow-the-key-macropad
+
+
+Make example for this keyboard (after setting up your build environment):
+```bash
+# default provided by Drop / Stack Overflow
+make massdrop/thekey:default
+# common modification where C = CTRL+C, V = CTRL+V
+make massdrop/thekey:url-copy-paste
+```
+
+Flashing example for this keyboard:
+```bash
+# install in dfu mode
+make massdrop/thekey:default:dfu
+```
+
+See the [build environment setup](https://docs.qmk.fm/#/getting_started_build_tools) and the [make instructions](https://docs.qmk.fm/#/getting_started_make_guide) for more information. Brand new to QMK? Start with our [Complete Newbs Guide](https://docs.qmk.fm/#/newbs).
+Make example for this keyboard (after setting up your build environment):
+
+## Bootloader
+
+Enter the bootloader as follows:
+* **Bootmagic reset**: Hold down the "Stack Overflow" key, the "left-most" or furthest from the USB plug while inserting the USB cable for a few seconds. The LEDs will **NOT** turn on.
+* **Physical reset button**: Briefly press and hold the reset button while pluggin in the USB port. The LEDs on the back will **NOT** turn on. Depending on your case revision, you may have to remove the 4 screws on the back plate to access the switch OR you can use the associated access hole on newer releases.

--- a/keyboards/massdrop/thekey_v2/rules.mk
+++ b/keyboards/massdrop/thekey_v2/rules.mk
@@ -1,0 +1,18 @@
+# MCU name
+MCU = atmega32u4
+
+# Bootloader selection
+BOOTLOADER = atmel-dfu
+
+# Build Options
+#   change yes to no to disable
+#
+BOOTMAGIC_ENABLE = yes      # Enable Bootmagic Lite
+MOUSEKEY_ENABLE = no        # Mouse keys
+EXTRAKEY_ENABLE = yes       # Audio control and System control
+CONSOLE_ENABLE = yes        # Console for debug
+COMMAND_ENABLE = yes        # Commands for debug and configuration
+NKRO_ENABLE = no            # Enable N-Key Rollover
+RGBLIGHT_ENABLE = yes       # Enable keyboard RGB underglow
+AUDIO_ENABLE = no           # Audio output
+MUSIC_ENABLE = no # No speaker/dac/etc, so no need for music mode

--- a/keyboards/massdrop/thekey_v2/thekey_v2.c
+++ b/keyboards/massdrop/thekey_v2/thekey_v2.c
@@ -1,0 +1,17 @@
+/* Copyright 2021 Joe Maples <joe@maples.dev>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "thekey_v2.h"

--- a/keyboards/massdrop/thekey_v2/thekey_v2.h
+++ b/keyboards/massdrop/thekey_v2/thekey_v2.h
@@ -1,0 +1,27 @@
+/* Copyright 2021 Joe Maples <joe@maples.dev>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "quantum.h"
+
+#define XXX KC_NO
+
+#define LAYOUT( \
+    K00, K01, K02  \
+) { \
+    { K00, K01, K02 }, \
+}


### PR DESCRIPTION
Per title, this PR adds proper support for "The Key V2 by Stack Overflow" from Massdrop. There are some slight HW differences compared to V1 - so using those builds as is causes LEDs to not work properly. So this PR fixes those LED/board differences and adds VIAL support for V2