### PR TITLE
Plain60: Fix conflict between Bootmagic Lite and qmk-dfu

### DIFF
--- a/keyboards/evyd13/plain60/keymaps/vial/config.h
+++ b/keyboards/evyd13/plain60/keymaps/vial/config.h
@@ -5,3 +5,8 @@
 #define VIAL_KEYBOARD_UID {0xED, 0x26, 0xCA, 0x6E, 0xC6, 0x33, 0x93, 0x24}
 #define VIAL_UNLOCK_COMBO_ROWS {1, 4}
 #define VIAL_UNLOCK_COMBO_COLS {0, 6}
+
+/* Moves Bootmagic Lite key from "Esc" to "b" to avoid conflict with qmk-dfu
+ * See https://docs.qmk.fm/#/flashing?id=qmk-dfu */
+#define BOOTMAGIC_LITE_ROW 3
+#define BOOTMAGIC_LITE_COLUMN 6

--- a/keyboards/evyd13/plain60/keymaps/vial/config.h
+++ b/keyboards/evyd13/plain60/keymaps/vial/config.h
@@ -6,7 +6,7 @@
 #define VIAL_UNLOCK_COMBO_ROWS {1, 4}
 #define VIAL_UNLOCK_COMBO_COLS {0, 6}
 
-/* Moves Bootmagic Lite key from "Esc" to "b" to avoid conflict with qmk-dfu
+/* Moves Bootmagic Lite key from "Esc" to "Left Control" to avoid conflict with qmk-dfu
  * See https://docs.qmk.fm/#/flashing?id=qmk-dfu */
-#define BOOTMAGIC_LITE_ROW 3
-#define BOOTMAGIC_LITE_COLUMN 6
+#define BOOTMAGIC_LITE_ROW 4
+#define BOOTMAGIC_LITE_COLUMN 0

--- a/keyboards/evyd13/plain60/keymaps/vial/rules.mk
+++ b/keyboards/evyd13/plain60/keymaps/vial/rules.mk
@@ -1,3 +1,6 @@
 VIA_ENABLE = yes
 VIAL_ENABLE = yes
 LTO_ENABLE = yes
+
+MOUSEKEY_ENABLE = yes
+NKRO_ENABLE = yes


### PR DESCRIPTION
Fixing conflict between the bootloader and Bootmagic Lite.

This board comes with qmk-dfu with QMK_ESC being the 0,0 key which creates a [conflict with the default Bootmagic Lite key](https://docs.qmk.fm/#/flashing?id=qmk-dfu).

Instead of disabling Bootmagic Lite I thought it was better to simply move the Bootmagic Lite key to the Left Control key instead.

I tested and it worked successfully.

I also realized the mousekeys and nkro were disabled. Since there was space available I enabled them, so all options are enabled. Firmware size got to 98% but flashed and worked successfully.
