### PR TITLE
pico: i2c: align code with chibios, avr, documentation

### DIFF
--- a/platforms/pico/drivers/i2c_master.c
+++ b/platforms/pico/drivers/i2c_master.c
@@ -7,6 +7,17 @@
 #include "pico/binary_info.h"
 #include "hardware/i2c.h"
 
+#ifndef I2C1_SCL_PIN
+#    define I2C1_SCL_PIN 3
+#endif
+#ifndef I2C1_SDA_PIN
+#    define I2C1_SDA_PIN 2
+#endif
+
+#ifndef I2C_DRIVER
+#    define I2C_DRIVER i2c1
+#endif
+
 static uint8_t i2c_address;
 
 static i2c_status_t pico_status_to_qmk(int res) {
@@ -25,16 +36,16 @@ void i2c_init_pico(void) {
         is_initialised = true;
 
         i2c_init(I2C_DRIVER, 50 * 1000);
-        gpio_set_function(I2C1_SCL, GPIO_FUNC_I2C);
-        gpio_set_function(I2C1_SDA, GPIO_FUNC_I2C);
-        gpio_pull_up(I2C1_SCL);
-        gpio_pull_up(I2C1_SDA);
+        gpio_set_function(I2C1_SCL_PIN, GPIO_FUNC_I2C);
+        gpio_set_function(I2C1_SDA_PIN, GPIO_FUNC_I2C);
+        gpio_pull_up(I2C1_SCL_PIN);
+        gpio_pull_up(I2C1_SDA_PIN);
         // Make the I2C pins available to picotool
-        bi_decl(bi_2pins_with_func(I2C1_SDA, I2C1_SCL, GPIO_FUNC_I2C));
+        bi_decl(bi_2pins_with_func(I2C1_SDA_PIN, I2C1_SCL_PIN, GPIO_FUNC_I2C));
     }
 }
 
-i2c_status_t i2c_start(uint8_t address) {
+i2c_status_t i2c_start(uint8_t address, uint16_t timeout) {
     i2c_address = address;
     return I2C_STATUS_SUCCESS;
 }

--- a/platforms/pico/drivers/i2c_master.h
+++ b/platforms/pico/drivers/i2c_master.h
@@ -26,26 +26,20 @@
 
 #include <stdint.h>
 
-#ifndef I2C1_SCL
-#    define I2C1_SCL 3
-#endif
-#ifndef I2C1_SDA
-#    define I2C1_SDA 2
-#endif
-
-#ifndef I2C_DRIVER
-#    define I2C_DRIVER i2c1
-#endif
-
 typedef int16_t i2c_status_t;
 
 #define I2C_STATUS_SUCCESS (0)
 #define I2C_STATUS_ERROR (-1)
 #define I2C_STATUS_TIMEOUT (-2)
 
+/* collides with:
+ * pico-sdk/src/rp2_comon/hardware_i2c/include/hardware/i2c.h::i2c_init
+ * hence the bodge...
+ */
 #define i2c_init() i2c_init_pico()
 void         i2c_init_pico(void);
-i2c_status_t i2c_start(uint8_t address);
+
+i2c_status_t i2c_start(uint8_t address, uint16_t timeout);
 i2c_status_t i2c_transmit(uint8_t address, const uint8_t* data, uint16_t length, uint16_t timeout);
 i2c_status_t i2c_receive(uint8_t address, uint8_t* data, uint16_t length, uint16_t timeout);
 i2c_status_t i2c_writeReg(uint8_t devaddr, uint8_t regaddr, const uint8_t* data, uint16_t length, uint16_t timeout);


### PR DESCRIPTION
some defines and function signatures did not quite match the
documented ones - which lead to compile issues while building the same
code that uses an i2c-driver based vial-qmk/driver for multiple
platforms: [avr, pico]

Signed-off-by: Johannes Schneider <johschneider@googlemail.com>

<!---
    For keyboard addition or changes, Vial will accept keyboards that implement "default" and "via" keymaps.
    For Vial-enabled keymaps please ensure that VIAL_INSECURE is not set.

    User keymaps (i.e. https://github.com/vial-kb/vial-qmk/tree/vial/users) will not be accepted at the moment.

    For other core changes, please explain what you are changing and why.

    Before submitting a PR, delete the entirety of this comment and document your changes.
-->
