### PR TITLE
pico: building default keymaps fails on missing raw_hid_receive

### DIFF
--- a/tmk_core/protocol/pico/pico.c
+++ b/tmk_core/protocol/pico/pico.c
@@ -272,9 +272,11 @@ void tud_hid_set_report_cb(uint8_t itf, uint8_t report_id, hid_report_type_t rep
             // LED status
             keyboard_indicator_led = buffer[0];
             break;
+#ifdef VIA_ENABLE
         case ITF_NUM_HID_RAW:
             raw_hid_receive((uint8_t*)buffer, bufsize);
             break;
+#endif
         default:
             break;
     }


### PR DESCRIPTION
minor build fix: building a default keymap that does not enable VIA leads to linker error, since raw_hid_receive is only available when quantum/via.c is pulled in

Signed-off-by: Johannes Schneider <johschneider@googlemail.com>

<!---
    For keyboard addition or changes, Vial will accept keyboards that implement "default" and "via" keymaps.
    For Vial-enabled keymaps please ensure that VIAL_INSECURE is not set.

    User keymaps (i.e. https://github.com/vial-kb/vial-qmk/tree/vial/users) will not be accepted at the moment.

    For other core changes, please explain what you are changing and why.

    Before submitting a PR, delete the entirety of this comment and document your changes.
-->
