### PR TITLE
rp2040 respects USB_POLLING_INTERVAL_MS

### DIFF
--- a/tmk_core/protocol/pico/usb_descriptors.c
+++ b/tmk_core/protocol/pico/usb_descriptors.c
@@ -144,7 +144,7 @@ uint8_t const desc_fs_configuration[] = {
     // address, size & polling interval
     TUD_HID_DESCRIPTOR(ITF_NUM_HID_KEYBOARD, 2, HID_ITF_PROTOCOL_NONE,
                        sizeof(desc_keyboard), EPNUM_HID_KEYBOARD_IN,
-                       CFG_TUD_HID_EP_BUFSIZE, 10),
+                       CFG_TUD_HID_EP_BUFSIZE, USB_POLLING_INTERVAL_MS),
     TUD_HID_INOUT_DESCRIPTOR(ITF_NUM_HID_RAW, 2, HID_ITF_PROTOCOL_NONE,
                              sizeof(desc_raw), EPNUM_HID_RAW_OUT,
                              EPNUM_HID_RAW_IN, CFG_TUD_HID_EP_BUFSIZE, 1),


### PR DESCRIPTION
In the old code, no matter the user's customization of `USB_POLLING_INTERVAL_MS` it would be hardcoded to 10 (0x0A). This causes it to poll at 125Hz.

This change causes the rp2040 code to respect `USB_POLLING_INTERVAL_MS`, allowing the user to get up to 1000Hz polling frequency by setting it to `1` in their `config.h`