### PR TITLE
fix: keebio/kbo5000 rows/cols transposition

### DIFF
--- a/keyboards/keebio/kbo5000/keymaps/vial/vial.json
+++ b/keyboards/keebio/kbo5000/keymaps/vial/vial.json
@@ -4,8 +4,8 @@
     "vendorId": "0xCB10",
     "lighting": "qmk_backlight_rgblight",
     "matrix": {
-        "rows": 10,
-        "cols": 12
+        "rows": 12,
+        "cols": 10
     },
     "layouts": {
                 "labels": [


### PR DESCRIPTION
https://github.com/vial-kb/vial-qmk/blob/1998b3e69f98f5def954927e4f5c27f5de95788b/keyboards/keebio/kbo5000/rev1/config.h#L30-L31

https://github.com/vial-kb/vial-qmk/blob/1998b3e69f98f5def954927e4f5c27f5de95788b/keyboards/keebio/kbo5000/keymaps/vial/vial.json#L7-L8

Update vial.json to match the keyboard config (h/t nhOmega#6827)