### PR TITLE
Macro count increased

### DIFF
--- a/quantum/dynamic_keymap.c
+++ b/quantum/dynamic_keymap.c
@@ -39,13 +39,7 @@
 #    define NUM_ENCODERS 0
 #endif
 
-#ifndef DYNAMIC_KEYMAP_LAYER_COUNT
-#    define DYNAMIC_KEYMAP_LAYER_COUNT 4
-#endif
-
-#ifndef DYNAMIC_KEYMAP_MACRO_COUNT
-#    define DYNAMIC_KEYMAP_MACRO_COUNT 16
-#endif
+_Static_assert(DYNAMIC_KEYMAP_MACRO_COUNT+MACRO00 < USER00, "DYNAMIC_KEYMAP_MACRO_COUNT too big.");
 
 #ifndef TOTAL_EEPROM_BYTE_COUNT
 #    error Unknown total EEPROM size. Cannot derive maximum for dynamic keymaps.

--- a/quantum/dynamic_keymap.h
+++ b/quantum/dynamic_keymap.h
@@ -26,6 +26,10 @@
 #    define DYNAMIC_KEYMAP_LAYER_COUNT 4
 #endif
 
+#ifndef DYNAMIC_KEYMAP_MACRO_COUNT
+#    define DYNAMIC_KEYMAP_MACRO_COUNT 16
+#endif
+
 uint8_t  dynamic_keymap_get_layer_count(void);
 void *   dynamic_keymap_key_to_eeprom_address(uint8_t layer, uint8_t row, uint8_t column);
 uint16_t dynamic_keymap_get_keycode(uint8_t layer, uint8_t row, uint8_t column);

--- a/quantum/via.c
+++ b/quantum/via.c
@@ -183,7 +183,7 @@ void via_set_layout_options(uint32_t value) {
 bool process_record_via(uint16_t keycode, keyrecord_t *record) {
     // Handle macros
     if (record->event.pressed) {
-        if (keycode >= MACRO00 && keycode <= MACRO15) {
+        if (keycode >= MACRO00 && keycode <= MACRO00 + DYNAMIC_KEYMAP_MACRO_COUNT - 1) {
             uint8_t id = keycode - MACRO00;
             dynamic_keymap_macro_send(id);
             return false;


### PR DESCRIPTION
This PR increases the amount of possible macros from 16 to 109 (at 110 it will start to overlap with USER00 keycodes)

With [#135](https://github.com/vial-kb/vial-gui/pull/135) the GUI will support macro_count higher than 32

@alexeyatbluescape from the discord asked to be notified