### PR TITLE
refactor: commented auto turn off led by default

### DIFF
--- a/keyboards/dumbpad/v3x/config.h
+++ b/keyboards/dumbpad/v3x/config.h
@@ -45,7 +45,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 // Cleanup RGB
 #ifdef RGB_MATRIX_ENABLE
 
-#define RGB_DISABLE_TIMEOUT 300000 // 5 minutes (5 * 60 * 1000ms)
+// #define RGB_DISABLE_TIMEOUT 300000 // 5 minutes (5 * 60 * 1000ms)
 #define RGB_DISABLE_WHEN_USB_SUSPENDED
 
 #define RGB_MATRIX_FRAMEBUFFER_EFFECTS // Heatmap, Rain


### PR DESCRIPTION
I think having LED turned on all the time is the preferable settings

so by default I want that timer line to be commented, so it's way easier for newbie