### PR TITLE
Added tap dance example compatible with Vial

### DIFF
--- a/docs/feature_tap_dance.md
+++ b/docs/feature_tap_dance.md
@@ -50,6 +50,27 @@ This means that you have `TAPPING_TERM` time to tap the key again; you do not ha
 
 ## Examples :id=examples
 
+### Vial specific example: `Toggle Layer 1` on Single Tap, `CAPS_LOCK` on Hold
+
+Vial made some changes to the tap dance logic, so just copy-pasting the QMK examples below doesn't work out of the box. But if you're familiar with setting up tap dances using the UI, you can edit your keymap so it uses Vial's system and automatically populates the entries after flashing the firmware, so you don't have to load a layout after every firmware update.
+
+In our example, we want to toggle between layers when tapping, and sending `CAPS_LOCK` on hold.
+
+In your `keymap.c` file, add the keycode `TD(0)` to the layout - tap dances in Vial go from 0 to 31.
+Further down, add:
+```c
+void keyboard_post_init_user(void) {
+    vial_tap_dance_entry_t td = { TG(1), KC_CAPSLOCK, KC_NO, KC_NO, TAPPING_TERM };
+    dynamic_keymap_set_tap_dance(0, &td); // the first value corresponds to the TD(i) slot
+}
+```
+The arguments for `vial_tap_dance_entry_t` are the same as in Vial's UI:
+
+![vial screenshot](https://user-images.githubusercontent.com/82843921/200892667-1aba0744-1130-454b-8858-9a8e9aa60446.png)
+
+
+
+## QMK Examples: Not compatible with Vial out of the box :id=qmk-examples
 ### Simple Example: Send `ESC` on Single Tap, `CAPS_LOCK` on Double Tap :id=simple-example
 
 Here's a simple example for a single definition:


### PR DESCRIPTION
<!---
    For keyboard addition or changes, Vial will accept keyboards that implement "default" and "via" keymaps.
    For Vial-enabled keymaps please ensure that VIAL_INSECURE is not set.

    User keymaps (i.e. https://github.com/vial-kb/vial-qmk/tree/vial/users) will not be accepted at the moment.

    For other core changes, please explain what you are changing and why.

    Before submitting a PR, delete the entirety of this comment and document your changes.
-->
