### PR TITLE
Allow overriding get_tapping_term if vial functions are disabled

### DIFF
--- a/quantum/vial.c
+++ b/quantum/vial.c
@@ -487,7 +487,12 @@ static void reload_tap_dance(void) {
 #endif
 
 #ifdef TAPPING_TERM_PER_KEY
+/* allow overriding get_tapping_term if vial features are disabled */
+#if defined(VIAL_TAP_DANCE_ENABLE) || defined(QMK_SETTINGS)
 uint16_t get_tapping_term(uint16_t keycode, keyrecord_t *record) {
+#else
+__attribute__((weak)) uint16_t get_tapping_term(uint16_t keycode, keyrecord_t *record) {
+#endif // defined(VIAL_TAP_DANCE_ENABLE) || defined(QMK_SETTINGS)
 #ifdef VIAL_TAP_DANCE_ENABLE
     if (keycode >= QK_TAP_DANCE && keycode <= QK_TAP_DANCE_MAX) {
         vial_tap_dance_entry_t td;


### PR DESCRIPTION
Currently overriding `get_tapping_term` is not supported, so it's not possible to use `TAPPING_TERM_PER_KEY` without `QMK_SETTINGS` which sometimes has to be disabled to reduce firmware size.
At the same time this PR will not allow overriding  `get_tapping_term`  if `VIAL_TAP_DANCE_ENABLE` is true to avoid breaking Tap Dance functionality.