### PR TITLE
FIX Keychron_q0 unlock keys

### DIFF
--- a/keyboards/keychron/q0/rev_0130/keymaps/vial/config.h
+++ b/keyboards/keychron/q0/rev_0130/keymaps/vial/config.h
@@ -4,5 +4,5 @@
 
 #define VIAL_KEYBOARD_UID {0xCD, 0xB9, 0xD4, 0xC9, 0x53, 0x9A, 0x68, 0xC3}
 
-#define VIAL_UNLOCK_COMBO_ROWS { 0, 2 }
-#define VIAL_UNLOCK_COMBO_COLS { 0, 13 }
+#define VIAL_UNLOCK_COMBO_ROWS { 0, 4 }
+#define VIAL_UNLOCK_COMBO_COLS { 0, 3 }


### PR DESCRIPTION
Remapped the enter key to unlock the keyboard.

The keyboard is just a numpad so the default enter key is on a different x, y location

Before this change, I wasn't able to unlock the keyboard

![image](https://user-images.githubusercontent.com/6133759/211173790-6f43c9e4-5a81-4e28-a921-31b3d48dee0a.png)


