### PR TITLE
Ignore python .venv folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -82,6 +82,7 @@ secrets.tar
 # Python things
 __pycache__
 .python-version
+.venv/
 
 # Prerequisites for updating ChibiOS
 /util/fmpp*


### PR DESCRIPTION
This PR just adds the `.venv/` folder to the `.gitignore`
