### PR TITLE
Addition of the Binepad BN006 6-key macropad

### DIFF
--- a/keyboards/binepad/bn006/config.h
+++ b/keyboards/binepad/bn006/config.h
@@ -27,6 +27,7 @@
     #define RGB_DISABLE_WHEN_USB_SUSPENDED  // turn off effects when suspended
     #define RGB_MATRIX_MAXIMUM_BRIGHTNESS 200  // limits maximum brightness of LEDs to 200 out of 255. If not defined maximum brightness is set to 255
     #define RGB_MATRIX_DEFAULT_MODE RGB_MATRIX_BREATHING  // Sets the default mode, if none has been set
+    #define RGB_MATRIX_STARTUP_MODE (RGB_MATRIX_DEFAULT_MODE)  // legacy, used by Vial
     #define RGB_TRIGGER_ON_KEYDOWN  // Triggers RGB keypress events on key down. This makes RGB control feel more responsive. This may cause RGB to not function properly on some boards
 
     // RGB Matrix Animation modes. Explicitly enabled

--- a/keyboards/binepad/bn006/config.h
+++ b/keyboards/binepad/bn006/config.h
@@ -1,0 +1,80 @@
+/* Copyright 2022 Binepad (@binpad) */
+/* SPDX-License-Identifier: GPL-2.0-or-later */
+
+#pragma once
+
+/*
+ * Wear Leveling EEPROM Emulation
+ */
+
+#define WEAR_LEVELING_LOGICAL_SIZE 2048                              // Number of bytes "exposed" to the rest of QMK and denotes the size of the usable EEPROM.
+#define WEAR_LEVELING_BACKING_SIZE (WEAR_LEVELING_LOGICAL_SIZE * 2)  // Number of bytes used by the wear-leveling algorithm for its underlying storage, and needs to be a multiple of the logical size.
+
+
+/*
+ * RGB Matrix
+ */
+
+#ifdef RGB_MATRIX_ENABLE
+    /* ===========================================================================================
+     * PLEASE NOTE:  Because the BN006 only has 6 keys, not all the animations are visually viable
+     * =========================================================================================== */
+
+    #define RGB_DI_PIN B15
+    #define RGB_MATRIX_LED_COUNT 6
+    #define DRIVER_LED_TOTAL (RGB_MATRIX_LED_COUNT)  // legacy, needed for Vial
+    #define RGB_MATRIX_KEYPRESSES  // reacts to keypresses
+    #define RGB_DISABLE_WHEN_USB_SUSPENDED  // turn off effects when suspended
+    #define RGB_MATRIX_MAXIMUM_BRIGHTNESS 200  // limits maximum brightness of LEDs to 200 out of 255. If not defined maximum brightness is set to 255
+    #define RGB_MATRIX_DEFAULT_MODE RGB_MATRIX_BREATHING  // Sets the default mode, if none has been set
+    #define RGB_TRIGGER_ON_KEYDOWN  // Triggers RGB keypress events on key down. This makes RGB control feel more responsive. This may cause RGB to not function properly on some boards
+
+    // RGB Matrix Animation modes. Explicitly enabled
+    // For full list of effects, see: https://docs.qmk.fm/#/feature_rgb_matrix?id=rgb-matrix-effects
+    #define ENABLE_RGB_MATRIX_SOLID_COLOR
+    // #define ENABLE_RGB_MATRIX_ALPHAS_MODS
+    #define ENABLE_RGB_MATRIX_GRADIENT_UP_DOWN
+    #define ENABLE_RGB_MATRIX_GRADIENT_LEFT_RIGHT
+    #define ENABLE_RGB_MATRIX_BREATHING
+    // #define ENABLE_RGB_MATRIX_BAND_SAT
+    // #define ENABLE_RGB_MATRIX_BAND_VAL
+    // #define ENABLE_RGB_MATRIX_BAND_PINWHEEL_SAT
+    // #define ENABLE_RGB_MATRIX_BAND_PINWHEEL_VAL
+    // #define ENABLE_RGB_MATRIX_BAND_SPIRAL_SAT
+    // #define ENABLE_RGB_MATRIX_BAND_SPIRAL_VAL
+    // #define ENABLE_RGB_MATRIX_CYCLE_ALL
+    // #define ENABLE_RGB_MATRIX_CYCLE_LEFT_RIGHT
+    // #define ENABLE_RGB_MATRIX_CYCLE_UP_DOWN
+    // #define ENABLE_RGB_MATRIX_RAINBOW_MOVING_CHEVRON
+    // #define ENABLE_RGB_MATRIX_CYCLE_OUT_IN
+    // #define ENABLE_RGB_MATRIX_CYCLE_OUT_IN_DUAL
+    // #define ENABLE_RGB_MATRIX_CYCLE_PINWHEEL
+    // #define ENABLE_RGB_MATRIX_CYCLE_SPIRAL
+    // #define ENABLE_RGB_MATRIX_DUAL_BEACON
+    // #define ENABLE_RGB_MATRIX_RAINBOW_BEACON
+    // #define ENABLE_RGB_MATRIX_RAINBOW_PINWHEELS
+    // #define ENABLE_RGB_MATRIX_RAINDROPS
+    // #define ENABLE_RGB_MATRIX_JELLYBEAN_RAINDROPS
+    // #define ENABLE_RGB_MATRIX_HUE_BREATHING
+    // #define ENABLE_RGB_MATRIX_HUE_PENDULUM
+    // #define ENABLE_RGB_MATRIX_HUE_WAVE
+    // #define ENABLE_RGB_MATRIX_PIXEL_RAIN
+    // #define ENABLE_RGB_MATRIX_PIXEL_FLOW
+    // #define ENABLE_RGB_MATRIX_PIXEL_FRACTAL
+    /* enabled only if RGB_MATRIX_FRAMEBUFFER_EFFECTS is defined */
+    // #define ENABLE_RGB_MATRIX_TYPING_HEATMAP
+    // #define ENABLE_RGB_MATRIX_DIGITAL_RAIN
+    /* enabled only of RGB_MATRIX_KEYPRESSES or RGB_MATRIX_KEYRELEASES is defined */
+    #define ENABLE_RGB_MATRIX_SOLID_REACTIVE_SIMPLE
+    #define ENABLE_RGB_MATRIX_SOLID_REACTIVE
+    // #define ENABLE_RGB_MATRIX_SOLID_REACTIVE_WIDE
+    // #define ENABLE_RGB_MATRIX_SOLID_REACTIVE_MULTIWIDE
+    // #define ENABLE_RGB_MATRIX_SOLID_REACTIVE_CROSS
+    // #define ENABLE_RGB_MATRIX_SOLID_REACTIVE_MULTICROSS
+    // #define ENABLE_RGB_MATRIX_SOLID_REACTIVE_NEXUS
+    // #define ENABLE_RGB_MATRIX_SOLID_REACTIVE_MULTINEXUS
+    #define ENABLE_RGB_MATRIX_SPLASH
+    // #define ENABLE_RGB_MATRIX_MULTISPLASH
+    #define ENABLE_RGB_MATRIX_SOLID_SPLASH
+    // #define ENABLE_RGB_MATRIX_SOLID_MULTISPLASH
+#endif

--- a/keyboards/binepad/bn006/info.json
+++ b/keyboards/binepad/bn006/info.json
@@ -1,0 +1,52 @@
+{
+    "manufacturer": "Binepad",
+    "keyboard_name": "BN006",
+    "maintainer": "Binepad",
+    "bootloader": "stm32duino",
+    "debounce": 5,
+    "diode_direction": "COL2ROW",
+    "features": {
+        "bootmagic": true,
+        "command": false,
+        "console": false,
+        "extrakey": true,
+        "mousekey": true,
+        "nkro": false,
+        "rgb_matrix": true
+    },
+    "matrix_pins": {
+        "cols": ["A15", "B3", "B4"],
+        "rows": ["A8", "C14"]
+    },
+    "processor": "STM32F103",
+    "url": "https://binepad.com",
+    "usb": {
+        "vid": "0x4249",
+        "pid": "0x426E",
+        "device_version": "1.0.0"
+    },
+    "rgb_matrix": {
+        "driver": "WS2812",
+        "layout": [
+            { "flags": 4, "matrix": [0, 0], "x": 0, "y": 0 },
+            { "flags": 4, "matrix": [0, 1], "x": 112, "y": 0 },
+            { "flags": 4, "matrix": [0, 2], "x": 224, "y": 0 },
+            { "flags": 4, "matrix": [1, 0], "x": 0, "y": 64 },
+            { "flags": 4, "matrix": [1, 1], "x": 112, "y": 64 },
+            { "flags": 4, "matrix": [1, 2], "x": 224, "y": 64 }
+        ]
+    },
+    "community_layouts": ["ortho_2x3"],
+    "layouts": {
+        "LAYOUT_ortho_2x3": {
+            "layout": [
+                { "matrix": [0, 0], "x": 0, "y": 0 },
+                { "matrix": [0, 1], "x": 1, "y": 0 },
+                { "matrix": [0, 2], "x": 2, "y": 0 },
+                { "matrix": [1, 0], "x": 0, "y": 1 },
+                { "matrix": [1, 1], "x": 1, "y": 1 },
+                { "matrix": [1, 2], "x": 2, "y": 1 }
+            ]
+        }
+    }
+}

--- a/keyboards/binepad/bn006/keymaps/default/keymap.c
+++ b/keyboards/binepad/bn006/keymaps/default/keymap.c
@@ -1,0 +1,18 @@
+/* Copyright 2022 Binepad (@binpad) */
+/* SPDX-License-Identifier: GPL-2.0-or-later */
+
+#include QMK_KEYBOARD_H
+
+const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+    /*
+     * ┌───┬───┬───┐
+     * │ A │ B │ C │
+     * ├───┼───┼───┤
+     * │ D │ E │ F │
+     * └───┴───┴───┘
+     */
+    [0] = LAYOUT_ortho_2x3(
+        KC_MPLY, KC_MUTE, KC_VOLU,
+        KC_MPRV, KC_MNXT, KC_VOLD
+    )
+};

--- a/keyboards/binepad/bn006/keymaps/vial/config.h
+++ b/keyboards/binepad/bn006/keymaps/vial/config.h
@@ -1,0 +1,9 @@
+/* Copyright 2022 Binepad (@binpad) */
+/* SPDX-License-Identifier: GPL-2.0-or-later */
+
+#pragma once
+
+#define VIAL_KEYBOARD_UID {0xE8, 0xA8, 0x51, 0x14, 0xBC, 0x64, 0xFB, 0x65}
+
+#define VIAL_UNLOCK_COMBO_ROWS { 0, 1 }
+#define VIAL_UNLOCK_COMBO_COLS { 0, 2 }

--- a/keyboards/binepad/bn006/keymaps/vial/keymap.c
+++ b/keyboards/binepad/bn006/keymaps/vial/keymap.c
@@ -1,0 +1,33 @@
+/* Copyright 2022 Binepad (@binpad) */
+/* SPDX-License-Identifier: GPL-2.0-or-later */
+
+#include QMK_KEYBOARD_H
+
+const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+    /*
+     * ┌───┬───┬───┐
+     * │ A │ B │ C │
+     * ├───┼───┼───┤
+     * │ D │ E │ F │
+     * └───┴───┴───┘
+     */
+    [0] = LAYOUT_ortho_2x3(
+        KC_MPLY, KC_MUTE, KC_VOLU,
+        KC_MPRV, KC_MNXT, KC_VOLD
+    ),
+
+    [1] = LAYOUT_ortho_2x3(
+        _______, _______, _______,
+        _______, _______, _______
+    ),
+
+    [2] = LAYOUT_ortho_2x3(
+        _______, _______, _______,
+        _______, _______, _______
+    ),
+
+    [3] = LAYOUT_ortho_2x3(
+        _______, _______, _______,
+        _______, _______, _______
+    )
+};

--- a/keyboards/binepad/bn006/keymaps/vial/rules.mk
+++ b/keyboards/binepad/bn006/keymaps/vial/rules.mk
@@ -1,0 +1,7 @@
+# Copyright 2022 Binepad (@binpad)
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+VIA_ENABLE = yes
+VIAL_ENABLE = yes
+VIALRGB_ENABLE = yes
+QMK_SETTINGS = no  # don't need these

--- a/keyboards/binepad/bn006/keymaps/vial/vial.json
+++ b/keyboards/binepad/bn006/keymaps/vial/vial.json
@@ -1,0 +1,10 @@
+{
+    "lighting": "vialrgb",
+    "matrix":{ "rows":2, "cols":3 },
+    "layouts":{
+        "keymap":[
+            ["0,0","0,1","0,2"],
+            ["1,0","1,1","1,2"]
+        ]
+    }
+}

--- a/keyboards/binepad/bn006/readme.md
+++ b/keyboards/binepad/bn006/readme.md
@@ -1,0 +1,26 @@
+# BINEPAD BN006
+
+The BN006 is a CNC machined 6-key macropad
+
+* Keyboard Maintainer: [Binepad](https://github.com/binepad)
+* Hardware Supported: BN006
+* Hardware Availability: [Binepad.com](https://www.binepad.com/bn006)
+
+Make example for this keyboard (after setting up your build environment):
+
+    make binepad/bn006:default
+
+Flashing example for this keyboard:
+
+    make binepad/bn006:default:flash
+
+See the [build environment setup](https://docs.qmk.fm/#/getting_started_build_tools) and the [make instructions](https://docs.qmk.fm/#/getting_started_make_guide) for more information.
+Brand new to QMK? Start with our [Complete Newbs Guide](https://docs.qmk.fm/#/newbs).
+
+## Bootloader
+
+Enter the bootloader in 3 ways:
+
+* **Bootmagic reset**: Hold down the key at (0,0) in the matrix (usually the top left key) and plug in the keyboard
+* **Physical reset button**: Briefly press the button on the back of the PCB
+* **Keycode in layout**: Press the key mapped to `QK_BOOT` *(or `RESET`)* if it is available

--- a/keyboards/binepad/bn006/rules.mk
+++ b/keyboards/binepad/bn006/rules.mk
@@ -1,0 +1,5 @@
+# Copyright 2022 Binepad (@binpad)
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+EPROM_DRIVER = wear_leveling
+WEAR_LEVELING_DRIVER = embedded_flash


### PR DESCRIPTION
## Description

The Binepad BN006 is a 6-Key macropad

BN006 is a CNC machined 6-key macropad designed by Binepad. The macropad can be configured via QMK to do just about anything!

* https://github.com/qmk/qmk_firmware/pull/18810

## Types of Changes

* [ ] Core
* [ ] Bugfix
* [ ] New feature
* [ ] Enhancement/optimization
* [x] Keyboard (addition or update)
* [x] Keymap/layout/userspace (addition or update)
* [ ] Documentation

## Issues Fixed or Closed by This PR

(Not applicable)

## Checklist

* [x] My code follows the code style of this project: [C](https://docs.qmk.fm/#/coding_conventions_c), [Python](https://docs.qmk.fm/#/coding_conventions_python)
* [x] I have read the [PR Checklist document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [x] I have read the [CONTRIBUTING document](https://docs.qmk.fm/#/contributing).
* [ ] I have added tests to cover my changes.
* [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
