### PR TITLE
tap dance: fix behavior when interrupted and hold is defined but not tap

### DIFF
--- a/quantum/vial.c
+++ b/quantum/vial.c
@@ -376,6 +376,8 @@ static void on_dance_finished(qk_tap_dance_state_t *state, void *user_data) {
         case SINGLE_TAP: {
             if (td_entry.on_tap)
                 vial_keycode_down(td_entry.on_tap);
+            else if (td_entry.on_hold)
+                vial_keycode_down(td_entry.on_hold);
             break;
         }
         case SINGLE_HOLD: {
@@ -414,6 +416,10 @@ static void on_dance_finished(qk_tap_dance_state_t *state, void *user_data) {
             if (td_entry.on_tap) {
                 vial_keycode_tap(td_entry.on_tap);
                 vial_keycode_down(td_entry.on_tap);
+            } else if (td_entry.on_double_tap) {
+                vial_keycode_down(td_entry.on_double_tap);
+            } else if (td_entry.on_tap_hold) {
+                vial_keycode_down(td_entry.on_tap_hold);
             }
             break;
         }
@@ -432,6 +438,8 @@ static void on_dance_reset(qk_tap_dance_state_t *state, void *user_data) {
         case SINGLE_TAP: {
             if (td_entry.on_tap)
                 vial_keycode_up(td_entry.on_tap);
+            else if (td_entry.on_hold)
+                vial_keycode_up(td_entry.on_hold);
             break;
         }
         case SINGLE_HOLD: {
@@ -467,6 +475,10 @@ static void on_dance_reset(qk_tap_dance_state_t *state, void *user_data) {
         case DOUBLE_SINGLE_TAP: {
             if (td_entry.on_tap) {
                 vial_keycode_up(td_entry.on_tap);
+            } else if (td_entry.on_double_tap) {
+                vial_keycode_up(td_entry.on_double_tap);
+            } else if (td_entry.on_tap_hold) {
+                vial_keycode_up(td_entry.on_tap_hold);
             }
             break;
         }


### PR DESCRIPTION
fall into hold on interrupt if corresponding tap action isn't defined for the case of double-tap vs tap-then-hold, continue to prefer the double-tap interrupt following the existing permissive=false model

<!---
    For keyboard addition or changes, Vial will accept keyboards that implement "default" and "via" keymaps.
    For Vial-enabled keymaps please ensure that VIAL_INSECURE is not set.

    User keymaps (i.e. https://github.com/vial-kb/vial-qmk/tree/vial/users) will not be accepted at the moment.

    For other core changes, please explain what you are changing and why.

    Before submitting a PR, delete the entirety of this comment and document your changes.
-->
