### PR TITLE
Fixing invalid property type in dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,7 +2,8 @@ version: 2
 updates:
   - package-ecosystem: "github-actions"
     directory: "/"
-    labels: [CI]
+    labels:
+      - "CI"
     reviewers:
       - "qmk/collaborators"
     schedule:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,7 +2,7 @@ version: 2
 updates:
   - package-ecosystem: "github-actions"
     directory: "/"
-    labels: CI
+    labels: [CI]
     reviewers:
       - "qmk/collaborators"
     schedule:


### PR DESCRIPTION
Apparently needs to be an array, but is currently just "CI", which is causing Dependabot check to fail on GitHub. (It's still just the one workflow that's being triggered to run, but it's now inside an array to stop GitHub complaining.)