### PR TITLE
[Fix] Remove VIAL_INSECURE from ymdk/id75

### DIFF
--- a/keyboards/ymdk/id75/keymaps/vial/rules.mk
+++ b/keyboards/ymdk/id75/keymaps/vial/rules.mk
@@ -1,5 +1,4 @@
 VIA_ENABLE = yes
 VIAL_ENABLE = yes
 LTO_ENABLE = yes # reduce firmware size
-VIAL_INSECURE = yes
 VIALRGB_ENABLE = yes


### PR DESCRIPTION
Keymap for ymdk/id75 had VIAL_INSECURE = yes, removed it, confirmed existing unlock combo works