### PR TITLE
[CI] detect clang-formatted VIAL_KEYBOARD_UID

### DIFF
--- a/util/ci_vial_verify_uid.py
+++ b/util/ci_vial_verify_uid.py
@@ -1,33 +1,33 @@
 #!/usr/bin/env python3
 from glob import glob
-import os
+from pathlib import Path
 import re
 import sys
 import struct
 from collections import defaultdict
 
-
 def main():
+
+    VIAL_UID_REGEX = re.compile(r"#\s*define\s+VIAL_KEYBOARD_UID\s+(?:\\(?:\n|\r)\s*)*{\s*((?:0(?:x|X)(?:[0-9a-fA-F]){2}\s*,\s*){7}(?:0(?:x|X)(?:[0-9a-fA-F]){2}))\s*}")
+
     error = 0
     uid_to_keyboards = defaultdict(set)
 
     for filename in glob("keyboards/**/vial.json", recursive=True):
         keyboard = filename[10:-10].split("/keymaps/")[0]
 
-        path = os.path.dirname(filename)
+        dirname = Path(filename).parents[0]
         uid = None
+
         while True:
-            config_h = os.path.join(path, "config.h")
-            if os.path.exists(config_h):
-                with open(config_h, "r") as inf:
-                    for line in inf:
-                        uid = re.findall(r"#define.*VIAL_KEYBOARD_UID.*{(.*)}", line)
-                        if uid:
-                            break
+            config_h = dirname.joinpath("config.h")
+            if config_h.exists() and config_h.stat().st_size < 100000:
+                content = config_h.read_text()
+                uid = VIAL_UID_REGEX.search(content)
             if uid:
                 break
-            path = os.path.dirname(path)
-            if path.endswith("keyboards"):
+            dirname = dirname.parents[0]
+            if dirname.match("keyboards"):
                 break
 
         if not uid:
@@ -35,7 +35,7 @@ def main():
             error = 1
             continue
 
-        uid = uid[0].split(",")
+        uid = uid[1].split(",")
         uid = [int(x, 16) for x in uid]
         uid = struct.pack("BBBBBBBB", *uid).hex()
         uid_to_keyboards[uid].add(keyboard)

--- a/util/ci_vial_verify_uid.py
+++ b/util/ci_vial_verify_uid.py
@@ -36,6 +36,7 @@ def main():
             continue
 
         uid = uid[1].split(",")
+        uid.reverse()
         uid = [int(x, 16) for x in uid]
         uid = struct.pack("BBBBBBBB", *uid).hex()
         uid_to_keyboards[uid].add(keyboard)


### PR DESCRIPTION
If somebody runs `clang-format` on their `vial/config.h` file, the macro expansion is moved onto a separate line. The current CI check doesn't handle this, resulting in false negatives (e.g. #420)

It won't detect commented-out code, but that should choke on compile.

I know effectively zero Python so I ended up rewriting the `os.path` calls as `pathlib` calls before discovering `read()`. [Not really seeing a reason to undo that](https://github.com/python/cpython/blob/5c4568a05a0a62b5947c55f68f9f2ecfb90a4f12/Lib/pathlib.py#L1171-LL1176), but please tell me why I'm wrong.

`uid.reverse()` is just so the UID output matches the Vial GUI.