### PR TITLE
Zoom65  Lite patch

### DIFF
--- a/keyboards/meletrix/zoom65_lite/config.h
+++ b/keyboards/meletrix/zoom65_lite/config.h
@@ -31,8 +31,8 @@
 #define DEBOUNCE 5
 
 /* Enable encoder */
-#define ENCODERS_PAD_A { B1 }
-#define ENCODERS_PAD_B { B0 }
+#define ENCODERS_PAD_A { B0 }
+#define ENCODERS_PAD_B { B1 }
 
 #define ENCODERS 1
 

--- a/keyboards/meletrix/zoom65_lite/keymaps/vial/keymap.c
+++ b/keyboards/meletrix/zoom65_lite/keymaps/vial/keymap.c
@@ -29,14 +29,14 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
         KC_ESC,  KC_1,    KC_2,    KC_3,    KC_4,    KC_5,    KC_6,    KC_7,    KC_8,    KC_9,    KC_0,    KC_MINS, KC_EQL,  KC_BSPC, KC_BSPC,   KC_VOLU, KC_MUTE, KC_VOLD,
         KC_TAB,  KC_Q,    KC_W,    KC_E,    KC_R,    KC_T,    KC_Y,    KC_U,    KC_I,    KC_O,    KC_P,    KC_LBRC, KC_RBRC, KC_BSLS, KC_DEL,
         KC_CAPS, KC_A,    KC_S,    KC_D,    KC_F,    KC_G,    KC_H,    KC_J,    KC_K,    KC_L,    KC_SCLN, KC_QUOT,          KC_ENT,  KC_PGUP,
-        KC_LSFT, KC_LSFT, KC_Z,    KC_X,    KC_C,    KC_V,    KC_B,    KC_N,    KC_M,    KC_COMM, KC_DOT,  KC_SLSH, KC_RSFT, KC_UP,   KC_END,
+        KC_LSFT, KC_LSFT, KC_Z,    KC_X,    KC_C,    KC_V,    KC_B,    KC_N,    KC_M,    KC_COMM, KC_DOT,  KC_SLSH, KC_RSFT, KC_UP,   KC_PGDN,
         KC_LCTL, KC_LGUI, KC_LALT,                   KC_SPC,  KC_SPC,  KC_SPC,           KC_RALT, MO(1),            KC_LEFT, KC_DOWN, KC_RGHT
     ),
     [1] = LAYOUT_all(
         KC_GRV,  KC_F1,   KC_F2,   KC_F3,   KC_F4,   KC_F5,   KC_F6,   KC_F7,   KC_F8,   KC_F9,   KC_F10,  KC_F11,  KC_F12,  _______, _______,   KC_MNXT, KC_MPLY, KC_MPRV,
-        _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______,
-        _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______,          _______, _______,
-        _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______,
+        _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, KC_PSCR, KC_SCRL, KC_PAUS, _______, _______,
+        _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______,          _______, KC_HOME,
+        _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, KC_END,
         _______, QK_BOOT, _______,                   _______, _______, _______,          _______, _______,          _______, _______, _______
     ),
     [2] = LAYOUT_all(


### PR DESCRIPTION
This PR aims to:
- fix the mapping for the encoder CW and CCW, originally they were swapped, volume was going up when CCW and viceversa
- add some missing keys to the default Vial keymap (Home, Page Down, End, Print Screen, Lock Scroll and Pause)
