### PR TITLE
refactor: build all CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,26 +1,94 @@
 name: CI
+on: [ pull_request, push, workflow_dispatch ]
 
-on:
-  push:
-  workflow_dispatch:
-  pull_request:
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+env:
+  REGEX_ANSI_COLOR: 's/\x1b\[[0-9;]*[mGKHF]//g'
+  REGEX_MAKE_OUTPUT: '/^g*make\[1]: \(Enter\|Leav\)ing directory ''/d'
+
+permissions: {}
 
 jobs:
-  build:
+  check-uid:
+    name: Check Vial UIDs for all keyboards
     runs-on: ubuntu-latest
 
-    container: qmkfm/qmk_cli
-
     steps:
-    - uses: actions/checkout@v2
+    - name: (actions) Checkout Vial repo
+      uses: actions/checkout@v3
       with:
-        fetch-depth: 0
+        persist-credentials: false
 
     - name: Verify Vial UID is unique
       run: python3 util/ci_vial_verify_uid.py
 
-    - name: Compile Vial keyboards
+  build-default:
+    name: Build default keymaps for Vial
+    runs-on: ubuntu-latest
+    container: ghcr.io/qmk/qmk_cli
+    env:
+      KEYMAP: default
+
+    steps:
+    - name: (actions) Checkout Vial repo
+      uses: actions/checkout@v3
+      with:
+        persist-credentials: false
+        submodules: recursive
+
+    - name: Build
+      id: build
       run: |
         git config --global --add safe.directory $(pwd)
-        make git-submodule
-        python3 util/ci_compile_vial_keyboards.py
+        qmk mass-compile -j $(nproc) $(qmk find -km vial | sed "s/:vial$/:${KEYMAP}/")
+
+    - name: Dump failure logs
+      if: ${{ failure() && steps.build.conclusion == 'failure' }}
+      run: |
+        echo '### Failure logs' | tee -a "${GITHUB_STEP_SUMMARY}"
+
+        cd .build || exit
+        for log in failed.log.*; do
+          pretty_logname="$(echo "${log}" | sed "s/^failed\.log\.[0-9]\+\.// ; s/\.${KEYMAP}$//")"
+
+          printf '\n::group::%s\n%s\n::endgroup::\n' "${pretty_logname}" "$(sed "${REGEX_MAKE_OUTPUT}" < "${log}")"
+          printf '\n<details>\n<summary>%s</summary>\n\n```\n%s\n```\n\n</details>\n' \
+             "${pretty_logname}" "$(sed "${REGEX_MAKE_OUTPUT} ; ${REGEX_ANSI_COLOR}" < "${log}")" >> "${GITHUB_STEP_SUMMARY}"
+        done
+
+  build-vial:
+    name: Build Vial keymaps
+    runs-on: ubuntu-latest
+    container: ghcr.io/qmk/qmk_cli
+    env:
+      KEYMAP: vial
+
+    steps:
+    - name: (actions) Checkout Vial repo
+      uses: actions/checkout@v3
+      with:
+        persist-credentials: false
+        submodules: recursive
+
+    - name: Build
+      id: build
+      run: |
+        git config --global --add safe.directory $(pwd)
+        qmk mass-compile -km "${KEYMAP}" -j $(nproc)
+
+    - name: Dump failure logs
+      if: ${{ failure() && steps.build.conclusion == 'failure' }}
+      run: |
+        echo '### Failure logs' | tee -a "${GITHUB_STEP_SUMMARY}"
+
+        cd .build || exit
+        for log in failed.log.*; do
+          pretty_logname="$(echo "${log}" | sed "s/^failed\.log\.[0-9]\+\.// ; s/\.${KEYMAP}$//")"
+
+          printf '\n::group::%s\n%s\n::endgroup::\n' "${pretty_logname}" "$(sed "${REGEX_MAKE_OUTPUT}" < "${log}")"
+          printf '\n<details>\n<summary>%s</summary>\n\n```\n%s\n```\n\n</details>\n' \
+            "${pretty_logname}" "$(sed "${REGEX_MAKE_OUTPUT} ; ${REGEX_ANSI_COLOR}" < "${log}")" >> "${GITHUB_STEP_SUMMARY}"
+        done

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ permissions: {}
 
 jobs:
   check-uid:
-    name: Check Vial UIDs for all keyboards
+    name: Check Vial UIDs
     runs-on: ubuntu-latest
 
     steps:
@@ -22,7 +22,7 @@ jobs:
       with:
         persist-credentials: false
 
-    - name: Verify Vial UID is unique
+    - name: Verify Vial UID is unique per-keyboard
       run: python3 util/ci_vial_verify_uid.py
 
   build-default:
@@ -43,14 +43,18 @@ jobs:
       id: build
       run: |
         git config --global --add safe.directory $(pwd)
-        qmk mass-compile -j $(nproc) $(qmk find -km vial | sed "s/:vial$/:${KEYMAP}/")
+        if ! qmk mass-compile -j $(nproc) $(qmk find -km vial | sed "s/:vial$/:${KEYMAP}/");
+          then
+          echo "::error::$(ls -1 .build/failed.log.* | wc -l) keymaps failed to build. See logs and/or job summary for details."
+          exit 1
+        fi
 
     - name: Dump failure logs
       if: ${{ failure() && steps.build.conclusion == 'failure' }}
       run: |
         echo '### Failure logs' | tee -a "${GITHUB_STEP_SUMMARY}"
 
-        cd .build || exit
+        cd .build || exit 1
         for log in failed.log.*; do
           pretty_logname="$(echo "${log}" | sed "s/^failed\.log\.[0-9]\+\.// ; s/\.${KEYMAP}$//")"
 
@@ -77,14 +81,18 @@ jobs:
       id: build
       run: |
         git config --global --add safe.directory $(pwd)
-        qmk mass-compile -km "${KEYMAP}" -j $(nproc)
+        if ! qmk mass-compile -km "${KEYMAP}" -j $(nproc);
+          then
+          echo "::error::$(ls -1 .build/failed.log.* | wc -l) keymaps failed to build. See logs and/or job summary for details."
+          exit 1
+        fi
 
     - name: Dump failure logs
       if: ${{ failure() && steps.build.conclusion == 'failure' }}
       run: |
         echo '### Failure logs' | tee -a "${GITHUB_STEP_SUMMARY}"
 
-        cd .build || exit
+        cd .build || exit 1
         for log in failed.log.*; do
           pretty_logname="$(echo "${log}" | sed "s/^failed\.log\.[0-9]\+\.// ; s/\.${KEYMAP}$//")"
 


### PR DESCRIPTION
Refactors the "build all relevant keyboards/keymaps" CI workflow.

- Runs ~150% faster (parallelized workloads, shallow checkouts, new QMK CLI tooling)
- w/r/t QMK CLI tooling, `find` and `mass-compile` also make the keyboard/keymap lookup/build less-naïve:
  - No longer attempts to build known-invalid combinations (e.g. `keebio/iris:vial`)
  - Builds many previously-overlooked combinations (e.g. `keebio/iris/rev7:vial`)
- Locks down permissions; this workflow doesn't need [write access to everything](https://github.com/vial-kb/vial-qmk/actions/runs/5171062827/jobs/9314372177#step:1:16) or to persist credentials
- Uses new QMK GH-based container, upgrades checkout action [per node 16 migration requirements](https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/)
- Limits concurrency, so runners won't spend hours building obsolete commits after someone realizes they made a typo 5 minutes in and/or accepts PR suggestions one at a time
- `grep` analogue no longer required to determine sources of failure

Feedback appreciated, as always.

---

An eventual goal of mine is to remove this check from most `push` and `pull_request` events in favor of a targeted approach that does things like [flagging the use of `VIAL_INSECURE=yes`](https://github.com/vial-kb/vial-qmk/pull/475#discussion_r1217379299), but that's still very much WIP.

P.S. since upstream is gradually introducing more workflows, you might want to put a `vial-` prefix on this and other Vial-specific workflows to prevent clashes.