### PR TITLE
fixed incorrect lock lights behavior for modelh controller

### DIFF
--- a/keyboards/ibm/modelh/info.json
+++ b/keyboards/ibm/modelh/info.json
@@ -11,12 +11,13 @@
         "extrakey": true,
         "mousekey": false,
         "nkro": false,
-        "sleep_led": true
+        "sleep_led": false
     },
     "indicators": {
         "caps_lock": "B8",
-        "num_lock": "B9",
-        "scroll_lock": "B7"
+        "num_lock": "B7",
+        "scroll_lock": "B9",
+        "on_state": 0
     },
     "matrix_pins": {
         "cols": ["A10", "A9", "A8", "B15", "B14", "B13", "B12", "B11", "B10", "B1", "B0", "A7", "A6", "A5", "A4", "A3"],


### PR DESCRIPTION
This PR fixes a wrong behavior for the lock lights of the IBM Model M keyboard when using the Model H replacement USB controller.
Scroll and Num lock were inverted and the LED states were also inverted. Finally, the LEDs stayed on during standby, which is now corrected.
<!---
    For keyboard addition or changes, Vial will accept keyboards that implement "default" and "via" keymaps.
    For Vial-enabled keymaps please ensure that VIAL_INSECURE is not set.

    User keymaps (i.e. https://github.com/vial-kb/vial-qmk/tree/vial/users) will not be accepted at the moment.

    For other core changes, please explain what you are changing and why.

    Before submitting a PR, delete the entirety of this comment and document your changes.
-->
