### PR TITLE
Fix up Issue #488

### DIFF
--- a/keyboards/keychron/q7/ansi/keymaps/vial/config.h
+++ b/keyboards/keychron/q7/ansi/keymaps/vial/config.h
@@ -1,9 +1,4 @@
-<<<<<<<< HEAD:keyboards/keychron/q7/ansi/keymaps/vial/config.h
 /* Copyright 2022 @ Keychron (https://www.keychron.com)
-========
-/* Copyright 2023 Finalkey
- * Copyright 2023 LiWenLiu <https://github.com/LiuLiuQMK>
->>>>>>>> qmk/master:keyboards/dotmod/dymium65/config.h
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -21,26 +16,10 @@
 
 #pragma once
 
-<<<<<<<< HEAD:keyboards/keychron/q7/ansi/keymaps/vial/config.h
-#define VIAL_KEYBOARD_UID {0xF4, 0xB4, 0xCC, 0xD0, 0xA0, 0x27, 0xA9, 0xB3}
+#define VIAL_KEYBOARD_UID {0x6A, 0xBD, 0xBF, 0x74, 0xD3, 0x2F, 0x55, 0xC2}
 
 #define VIAL_UNLOCK_COMBO_ROWS {0, 2}
 #define VIAL_UNLOCK_COMBO_COLS {0, 13}
 
 /* Set dynamic keymap layer counts to 5 */
 #define DYNAMIC_KEYMAP_LAYER_COUNT 5
-========
-/* Mechanical locking support. Use KC_LCAP, KC_LNUM or KC_LSCR instead in keymap */
-#define LOCKING_SUPPORT_ENABLE
-/* Locking resynchronize hack */
-#define LOCKING_RESYNC_ENABLE
-
-// The number of LEDs connected
-#define RGB_MATRIX_LED_COUNT 66
-#define RGB_MATRIX_KEYPRESSES
-#define RGB_MATRIX_KEYRELEASES
-#define RGB_MATRIX_FRAMEBUFFER_EFFECTS
-#define RGB_DISABLE_AFTER_TIMEOUT 0
-#define RGB_MATRIX_LED_FLUSH_LIMIT 16
-#define RGB_MATRIX_MAXIMUM_BRIGHTNESS 200
->>>>>>>> qmk/master:keyboards/dotmod/dymium65/config.h


### PR DESCRIPTION
Adds back original content of `keychron/q7/ansi/keymaps/vial/config.h` that was somehow replaced with content from another keyboard during `git merge`, rectifying https://github.com/vial-kb/vial-qmk/issues/488.