### PR TITLE
fix: revert EE_HANDS migration for keycapsss/3w6_2040

### DIFF
--- a/keyboards/keycapsss/3w6_2040/config.h
+++ b/keyboards/keycapsss/3w6_2040/config.h
@@ -8,6 +8,7 @@
 #define SERIAL_USART_PIN_SWAP     // Swap TX and RX pins if keyboard is master halve.
 #define SERIAL_USART_SPEED 921600 // Sped :)
 #define USB_VBUS_PIN GP19         // for rp2040 | When USB_VBUS_PIN is not defined, SPLIT_USB_DETECT is used.
+#define EE_HANDS                  // Split handedness via eeprom
 #define SPLIT_LED_STATE_ENABLE    // Sync host leds (caps lock, ...)
 #define SPLIT_LAYER_STATE_ENABLE  // Enables syncing of the layer state between both halves
 #define SPLIT_POINTING_ENABLE     // Transmitting the pointing device status to the master side

--- a/keyboards/keycapsss/3w6_2040/info.json
+++ b/keyboards/keycapsss/3w6_2040/info.json
@@ -45,7 +45,6 @@
     },
     "split": {
         "enabled": true,
-        "main": "eeprom",
         "transport": {
             "protocol": "serial"
         }


### PR DESCRIPTION
Handedness assignment in `info.json` [doesn't actually work yet](https://github.com/qmk/qmk_firmware/pull/18254).