### PR TITLE
Add VialRGB_ENABLE to mini36 keyboard

### DIFF
--- a/keyboards/controllerworks/mini36/keymaps/vial/rules.mk
+++ b/keyboards/controllerworks/mini36/keymaps/vial/rules.mk
@@ -1,2 +1,3 @@
 VIA_ENABLE = yes
 VIAL_ENABLE = yes
+VIALRGB_ENABLE = yes 


### PR DESCRIPTION
Add VIALRGB_ENABLE to mini36 vial keymap rules.mk to remove Vial app error message.
