### PR TITLE
docs: pull request comment update

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,10 +1,29 @@
 <!---
-    For keyboard addition or changes, Vial will accept keyboards that implement "default" and "via" keymaps.
-    For Vial-enabled keymaps please ensure that VIAL_INSECURE is not set.
 
-    User keymaps (i.e. https://github.com/vial-kb/vial-qmk/tree/vial/users) will not be accepted at the moment.
+    If you are submitting a Vial-enabled keymap for a keyboard in QMK:
 
-    For other core changes, please explain what you are changing and why.
+    - Keymaps will not be accepted with VIAL_INSECURE=yes.
+    - Avoid changing keyboard-level code if possible. (ex: switching the encoder pins in info.json)
+    - Please name your keymap "vial". Personal keymaps are not accepted at this time.
+      - If your Vial keymap only works for a specific keyboard revision, place it under that revision's folder. (ex: keyboards/planck/rev6_drop/keymaps/vial and keyboards/planck/ez/glow/keymaps/vial)
+
+    If you are submitting a new keyboard with keymaps:
+
+    - If you are also submitting this keyboard to QMK, please try to submit mostly the same code to both repos if possible.
+    - If you are not submitting this keyboard to QMK, only include "default" and "vial" keymaps. VIA firmware can no longer be built by this repository.
+
+    ------
+
+    For all keyboard and keymap submissions:
+
+    As the submitter, you are ultimately responsible for maintaining the keyboards/keymaps you submit.
+    Vial contributors will try to fix compilation issues as updates are made, but are not always familiar with and often can't test specific keymaps/keyboards.
+
+    Vial is decentralized, so inclusion in the vial-qmk repository is optional. Unmaintained keymaps/keyboards which are broken and cannot be fixed without extensive rework or strong familiarity with the hardware may be removed from this repository, with or without warning.
+
+    ------
+
+    For core changes, please explain what you are changing and why.
 
     Before submitting a PR, delete the entirety of this comment and document your changes.
 -->


### PR DESCRIPTION
Updated PR guidelines and disclaimers. ~~stop trying to sneak in encoder pin changes for the entire keyboard~~

I think they make sense, but it's now a long comment. Maybe this should be a page on the website instead, and the PR guidelines here just link to it, but the likelihood of anyone bothering to click that and read it is...slim. Feedback more than welcome, as always.