### PR TITLE
fix: run concurrent CI on PR branches with identical names

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 on: [ pull_request, push, workflow_dispatch ]
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 env:


### PR DESCRIPTION
Using `github.head_ref` only works well when PRs are submitted from branches with unique names.

Using `github.ref` will change the grouping from `CI-<branch_name>` to `CI-refs/pull/<pr_number>/merge`...so CI runs for branches named `vial` on two different forks will no longer interrupt each other.