### PR TITLE
fix yd60mq split spacebar layout

### DIFF
--- a/keyboards/ymdk/yd60mq/keymaps/vial/vial.json
+++ b/keyboards/ymdk/yd60mq/keymaps/vial/vial.json
@@ -499,7 +499,7 @@
         {
           "w": 1.25
         },
-        "4,10\n\n\n4,4",
+        "4,10\n\n\n4,5",
         {
           "w": 1.25
         },
@@ -508,14 +508,60 @@
           "w": 1.25
         },
         "4,13\n\n\n4,5"
+      ],
+	  [
+        {
+          "y": 0.25,
+          "x": 24.75,
+          "w": 1.25
+        },
+        "4,0\n\n\n4,6",
+        {
+          "w": 1.25
+        },
+        "4,1\n\n\n4,6",
+        {
+          "w": 1.25
+        },
+        "4,2\n\n\n4,6",
+        {
+          "c": "#cccccc",
+          "w": 2.75
+        },
+        "4,3\n\n\n4,6",
+        {
+          "w": 1.25
+        },
+        "4,7\n\n\n4,6",
+        {
+          "w": 2.25
+        },
+        "4,8\n\n\n4,6",
+        {
+          "c": "#aaaaaa",
+          "w": 1.25
+        },
+        "4,9\n\n\n4,6",
+        {
+          "w": 1.25
+        },
+        "4,10\n\n\n4,6",
+        {
+          "w": 1.25
+        },
+        "4,12\n\n\n4,6",
+        {
+          "w": 1.25
+        },
+        "4,13\n\n\n4,6"
       ]
     ],
 "labels": [
   "Split Backspace",
   "Stepped Caps Lock",
   "ISO Enter",
-  ["ZXC ROW / R4", "ANSI Standard", "ANSI Split Right Shift", "ANSI Big Question Mark Arrow Keys", "ISO Standart", "ISO Split Right Shift", "ISO Big Question Mark Arrow Keys", "2u Left Shift Arrow keys"],
-  ["Bottom Row", "ANSI", "Tsangan", "HHKB", "Arrow Keys", "Japanese", "Split Spacebar"]
+  ["ZXC ROW / R4", "ANSI Standard", "ANSI Split Right Shift", "ANSI Big Question Mark Arrow Keys", "ISO Standard", "ISO Split Right Shift", "ISO Big Question Mark Arrow Keys", "2u Left Shift Arrow keys"],
+  ["Bottom Row", "ANSI", "Tsangan", "HHKB", "Arrow Keys", "Japanese", "Split Spacebar 2.75u Right", "Split Spacebar 2.75u Left"]
 ]
 }
 }


### PR DESCRIPTION
split spacebar layout fix
option for left 2.75u split spacebar variant 
spelling

