### PR TITLE
Adds gpio.h include to ps2_vendor driver

### DIFF
--- a/platforms/chibios/drivers/vendor/RP/RP2040/ps2_vendor.c
+++ b/platforms/chibios/drivers/vendor/RP/RP2040/ps2_vendor.c
@@ -1,6 +1,7 @@
 // Copyright 2022 Marek Kraus (@gamelaster)
 // SPDX-License-Identifier: GPL-2.0-or-later
 
+#include "gpio.h"
 #include "hardware/pio.h"
 #include "hardware/clocks.h"
 #include "ps2.h"


### PR DESCRIPTION
Core change, just catching up to QMK current..
This enables trackpoint builds on RP2040 to work correctly with Vial by fixing the ps2_vendor driver to include the RP2040 GPIO symbols.

Without including gpio.h, PS2 assignments using pin macros like "GP23" or "GP24" don't work. This include exists in the QMK version of this file already, and works properly there.  So I'm proposing to include it -- but if picking it up directly from QMK is better, that's fine, but it would be nice to fix it now rather than later since it's such a simple touch.