### PR TITLE
Fix encoder for soldered Artemis Paragon

### DIFF
--- a/keyboards/artemis/paragon/hotswap/info.json
+++ b/keyboards/artemis/paragon/hotswap/info.json
@@ -3,6 +3,11 @@
         "cols": ["F7", "F6", "F5", "F4", "F1", "F0", "C7", "E6", "B0", "B3", "B6", "B5", "B4", "D7", "D4", "D6"],
         "rows": ["D2", "D1", "D0", "B2", "B1", "C6"]
     },
+    "encoder": {
+        "rotary": [
+            { "pin_a": "D3", "pin_b": "D5", "resolution": 2 }
+        ]
+    },
     "layouts": {
         "LAYOUT_ansi_rwkl": {
             "layout": [

--- a/keyboards/artemis/paragon/info.json
+++ b/keyboards/artemis/paragon/info.json
@@ -18,11 +18,6 @@
     },
     "processor": "atmega32u4",
     "url": "",
-    "encoder": {
-        "rotary": [
-            { "pin_a": "D3", "pin_b": "D5", "resolution": 2 }
-        ]
-    },
     "usb": {
         "device_version": "1.0.0",
         "pid": "0x3449",

--- a/keyboards/artemis/paragon/soldered/info.json
+++ b/keyboards/artemis/paragon/soldered/info.json
@@ -3,6 +3,11 @@
         "cols": ["E6", "F0", "F1", "F4", "F5", "F6", "F7", "B0", "B1", "B3", "D0", "D1", "D2", "D3", "D7", "D5"],
         "rows": ["B2", "C7", "C6", "B6", "B5", "B4"]
     },
+    "encoder": {
+        "rotary": [
+            { "pin_a": "D4", "pin_b": "D6", "resolution": 2 }
+        ]
+    },
     "layouts": {
         "LAYOUT_ansi_rwkl": {
             "layout": [


### PR DESCRIPTION
This fixes the encoder functionality for the soldered version of the Artemis Paragon PCB.

This fix gives the hotswap and soldered versions their own encoder config in info.json, and corrects the pins for the soldered version.
