### PR TITLE
Make Ploopy Adept work with Vial

### DIFF
--- a/keyboards/ploopyco/madromys/keymaps/vial/config.h
+++ b/keyboards/ploopyco/madromys/keymaps/vial/config.h
@@ -1,0 +1,8 @@
+/* SPDX-License-Identifier: GPL-2.0-or-later */
+
+#pragma once
+
+#define VIAL_KEYBOARD_UID {0x3D, 0x23, 0x68, 0xC4, 0x1F, 0x4E, 0x55, 0x8C}
+
+#define VIAL_UNLOCK_COMBO_ROWS { 0, 0 }
+#define VIAL_UNLOCK_COMBO_COLS { 3, 5 }

--- a/keyboards/ploopyco/madromys/keymaps/vial/keymap.c
+++ b/keyboards/ploopyco/madromys/keymaps/vial/keymap.c
@@ -1,0 +1,22 @@
+/* Copyright 2023 Colin Lam (Ploopy Corporation)
+ * Copyright 2020 Christopher Courtney, aka Drashna Jael're  (@drashna) <drashna@live.com>
+ * Copyright 2019 Sunjun Kim
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#include QMK_KEYBOARD_H
+
+const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+    [0] = LAYOUT( KC_BTN4, KC_BTN5, DRAG_SCROLL, KC_BTN2, KC_BTN1, KC_BTN3 )
+};

--- a/keyboards/ploopyco/madromys/keymaps/vial/rules.mk
+++ b/keyboards/ploopyco/madromys/keymaps/vial/rules.mk
@@ -1,0 +1,2 @@
+VIA_ENABLE = yes
+VIAL_ENABLE = yes

--- a/keyboards/ploopyco/madromys/keymaps/vial/vial.json
+++ b/keyboards/ploopyco/madromys/keymaps/vial/vial.json
@@ -1,0 +1,46 @@
+{
+  "name": "PloopyCo Trackball",
+  "vendorId": "0x5043",
+  "productId": "0x5442",
+  "lighting": "none",
+  "customKeycodes": [
+    {"name": "DPI Config", "title": "DPI Config", "shortName": "DPI"},
+    {"name": "Drag Scroll", "title": "Drag Scroll", "shortName": "Drag\nScrl"}
+  ],
+  "matrix": {"rows": 1, "cols": 6},
+  "layouts": {
+    "keymap": [
+      [
+        {
+          "h": 1.5
+        },
+        "0,0",
+        {
+          "x": -1,
+          "y": -1.7,
+          "h": 1.5
+        },
+        "0,1",
+        {
+          "x": 0.2
+        },
+        "0,2",
+        {
+          "x": 0.2
+        },
+        "0,3",
+        {
+          "x": 0.2,
+          "h": 1.5
+        },
+        "0,4",
+        {
+          "x": -1,
+          "y": 1.7,
+          "h": 1.5
+        },
+        "0,5"
+      ]
+    ]
+  }
+}


### PR DESCRIPTION
Identical copy of the via keymap except added files needed by vial.