### PR TITLE
fix: detect CONVERT_TO vs MCU in rules.mk

### DIFF
--- a/keyboards/argo_works/ishi/80/mk0_avr/keymaps/vial/rules.mk
+++ b/keyboards/argo_works/ishi/80/mk0_avr/keymaps/vial/rules.mk
@@ -2,7 +2,7 @@ VIA_ENABLE = yes
 VIAL_ENABLE = yes
 LTO_ENABLE = yes
 
-ifeq ($(strip $(MCU)), atmega32u4)
+ifeq ($(strip $(CONVERT_TO)), )
     MAGIC_ENABLE = no
     SPACE_CADET_ENABLE = no
     COMBO_ENABLE = no

--- a/keyboards/argo_works/ishi/80/mk0_avr_extra/keymaps/vial/rules.mk
+++ b/keyboards/argo_works/ishi/80/mk0_avr_extra/keymaps/vial/rules.mk
@@ -3,7 +3,7 @@ VIA_ENABLE = yes
 VIAL_ENABLE = yes
 LTO_ENABLE = yes
 
-ifeq ($(strip $(MCU)), atmega32u4)
+ifeq ($(strip $(CONVERT_TO)), )
     MAGIC_ENABLE = no
     SPACE_CADET_ENABLE = no
     COMBO_ENABLE = no

--- a/keyboards/boardsource/lulu/keymaps/vial/rules.mk
+++ b/keyboards/boardsource/lulu/keymaps/vial/rules.mk
@@ -3,7 +3,7 @@ VIAL_ENABLE = yes
 
 VIALRGB_ENABLE = yes
 
-ifeq ($(strip $(MCU)), atmega32u4)
+ifeq ($(strip $(CONVERT_TO)), )
     QMK_SETTINGS = no
     COMBO_ENABLE = no
     MOUSEKEY_ENABLE = no

--- a/keyboards/handwired/prkl30/keymaps/vial/rules.mk
+++ b/keyboards/handwired/prkl30/keymaps/vial/rules.mk
@@ -8,6 +8,6 @@ EXTRAKEY_ENABLE = yes
 CONSOLE_ENABLE = no
 COMMAND_ENABLE = no
 
-ifeq ($(strip $(MCU)), atmega32u4)
+ifeq ($(strip $(CONVERT_TO)), )
     QMK_SETTINGS = no
 endif

--- a/keyboards/mechwild/bde/rev2/keymaps/vial/rules.mk
+++ b/keyboards/mechwild/bde/rev2/keymaps/vial/rules.mk
@@ -8,7 +8,7 @@ TAP_DANCE_ENABLE = yes
 GRAVE_ESC_ENABLE = yes
 SPACE_CADET_ENABLE = yes
 
-ifeq ($(strip $(MCU)), atmega32u4)
+ifeq ($(strip $(CONVERT_TO)), )
     QMK_SETTINGS = no
     
     KEY_OVERRIDE_ENABLE = no

--- a/keyboards/mechwild/clunker/keymaps/vial/rules.mk
+++ b/keyboards/mechwild/clunker/keymaps/vial/rules.mk
@@ -3,7 +3,7 @@ VIAL_ENABLE = yes
 LTO_ENABLE = yes
 ENCODER_MAP_ENABLE = yes
 
-ifeq ($(strip $(MCU)), atmega32u4)
+ifeq ($(strip $(CONVERT_TO)), )
     MAGIC_ENABLE = no
     SPACE_CADET_ENABLE = no
     #TAP_DANCE_ENABLE = no    # if space becomes an issue, uncomment

--- a/keyboards/mechwild/mokulua/mirrored/keymaps/vial/rules.mk
+++ b/keyboards/mechwild/mokulua/mirrored/keymaps/vial/rules.mk
@@ -4,7 +4,7 @@ VIAL_ENABLE          = yes
 
 ENCODER_MAP_ENABLE   = yes
 
-ifeq ($(strip $(MCU)), atmega32u4)
+ifeq ($(strip $(CONVERT_TO)), )
     QMK_SETTINGS         = no
 
 	MAGIC_ENABLE         = no

--- a/keyboards/mechwild/mokulua/standard/keymaps/vial/rules.mk
+++ b/keyboards/mechwild/mokulua/standard/keymaps/vial/rules.mk
@@ -4,7 +4,7 @@ VIAL_ENABLE          = yes
 
 ENCODER_MAP_ENABLE   = yes
 
-ifeq ($(strip $(MCU)), atmega32u4)
+ifeq ($(strip $(CONVERT_TO)), )
     QMK_SETTINGS         = no
 
 	MAGIC_ENABLE         = no

--- a/keyboards/mechwild/murphpad/keymaps/vial/rules.mk
+++ b/keyboards/mechwild/murphpad/keymaps/vial/rules.mk
@@ -5,7 +5,7 @@ ENCODER_MAP_ENABLE = yes
 MOUSEKEY_ENABLE = yes
 COMBOS_ENABLE = yes
 
-ifeq ($(strip $(MCU)), atmega32u4)
+ifeq ($(strip $(CONVERT_TO)),)
     QMK_SETTINGS = no
     TAP_DANCE_ENABLE = no
     KEY_OVERRIDE_ENABLE = no

--- a/keyboards/reedskeebs/alish40/keymaps/vial/rules.mk
+++ b/keyboards/reedskeebs/alish40/keymaps/vial/rules.mk
@@ -2,7 +2,7 @@ ENCODER_MAP_ENABLE = yes
 VIA_ENABLE = yes
 VIAL_ENABLE = yes
 
-ifeq ($(strip $(MCU)), atmega32u4)
+ifeq ($(strip $(CONVERT_TO)), )
     GRAVE_ESC_ENABLE = no
     KEY_OVERRIDE_ENABLE = no
     LTO_ENABLE = yes

--- a/keyboards/splitkb/aurora/lily58/rev1/keymaps/vial/rules.mk
+++ b/keyboards/splitkb/aurora/lily58/rev1/keymaps/vial/rules.mk
@@ -5,7 +5,7 @@ VIA_ENABLE = yes
 VIAL_ENABLE = yes
 
 # Saving space on atmega32u4
-ifeq ($(strip $(MCU)), atmega32u4)
+ifeq ($(strip $(CONVERT_TO)), )
     OLED_ENABLE = no
     MOUSEKEY_ENABLE = no
     COMBO_ENABLE = no

--- a/keyboards/tweetydabird/lotus58/keymaps/vial/rules.mk
+++ b/keyboards/tweetydabird/lotus58/keymaps/vial/rules.mk
@@ -7,7 +7,7 @@ VIAL_ENABLE = yes
 ENCODER_MAP_ENABLE = yes
 
 # Reduce size on atmega32u4
-ifeq ($(strip $(MCU)), atmega32u4)
+ifeq ($(strip $(CONVERT_TO)), )
     TAP_DANCE_ENABLE = no
     QMK_SETTINGS = no
     KEY_OVERRIDE_ENABLE = no


### PR DESCRIPTION
The value of `MCU` no longer changes to match the converter, resulting in features being unnecessarily disabled on STM32/RP2040-powered Pro Micro replacements. Check for a blank `CONVERT_TO` instead.