### PR TITLE
[Keymap] Add 2 more layers to Ferris Sweep keymap and 3 more Tap Dance

### DIFF
--- a/keyboards/ferris/sweep/keymaps/vial/config.h
+++ b/keyboards/ferris/sweep/keymaps/vial/config.h
@@ -2,6 +2,8 @@
 
 #pragma once
 
+#define DYNAMIC_KEYMAP_LAYER_COUNT 6
+#define VIAL_TAP_DANCE_ENTRIES 10
 #define VIAL_KEYBOARD_UID {0x47, 0x97, 0x7E, 0x32, 0xC9, 0xAC, 0x13, 0xF3}
 
 #define VIAL_UNLOCK_COMBO_ROWS { 2, 3, 0, 0, 0 }

--- a/keyboards/ferris/sweep/keymaps/vial/keymap.c
+++ b/keyboards/ferris/sweep/keymaps/vial/keymap.c
@@ -40,4 +40,18 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
     KC_TRNS,  KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS,         KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS,
                                     KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS
   ),
+
+  [4] = LAYOUT(
+    KC_TRNS,  KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS,         KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS,
+    KC_TRNS,  KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS,         KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS,
+    KC_TRNS,  KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS,         KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS,
+                                    KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS
+  ),
+
+  [5] = LAYOUT(
+    KC_TRNS,  KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS,         KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS,
+    KC_TRNS,  KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS,         KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS,
+    KC_TRNS,  KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS,         KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS,
+                                    KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS
+  ),
 };


### PR DESCRIPTION
Tweaked Ferris Sweep to add layers 4-5 and Tap Dance 8-10. Leaves about 2.2kB for macros for me.

Feel free to add suggestions! 🙂