### PR TITLE
Fix int size of mk_wheel_interval to match mousekey.c

### DIFF
--- a/quantum/mousekey.h
+++ b/quantum/mousekey.h
@@ -183,7 +183,11 @@ extern uint8_t mk_interval;
 extern uint8_t mk_max_speed;
 extern uint8_t mk_time_to_max;
 extern uint8_t mk_wheel_delay;
+#ifdef MK_KINETIC_SPEED
+extern uint16_t mk_wheel_interval;
+#else
 extern uint8_t mk_wheel_interval;
+#endif
 extern uint8_t mk_wheel_max_speed;
 extern uint8_t mk_wheel_time_to_max;
 


### PR DESCRIPTION
Getting compile errors when enabling [kinetic mode](https://docs.qmk.fm/features/mouse_keys#kinetic-mode):
```
#define MK_KINETIC_SPEED
```
Error:
```
Compiling: quantum/mousekey.c                                                                      quantum/mousekey.c:83:10: error: conflicting types for 'mk_wheel_interval'; have 'uint16_t' {aka 'short unsigned int'}
   83 | uint16_t mk_wheel_interval = 1000U / MOUSEKEY_WHEEL_INITIAL_MOVEMENTS;
      |          ^~~~~~~~~~~~~~~~~
In file included from quantum/mousekey.c:25:
quantum/mousekey.h:186:16: note: previous declaration of 'mk_wheel_interval' with type 'uint8_t' {aka 'unsigned char'}
  186 | extern uint8_t mk_wheel_interval;
      |                ^~~~~~~~~~~~~~~~~
 [ERRORS]
```

Need to add logic around the int size of `mk_wheel_interval` to match what's in `mousekey.c`