### PR TITLE
QS.auto_shift to respect AUTO_SHIFT_ENABLE

### DIFF
--- a/quantum/qmk_settings.c
+++ b/quantum/qmk_settings.c
@@ -162,7 +162,7 @@ void qmk_settings_init(void) {
 
 void qmk_settings_reset(void) {
     QS.grave_esc_override = 0;
-    QS.auto_shift = 0;
+    QS.auto_shift = AUTO_SHIFT_ENABLE;
     QS.auto_shift_timeout = AUTO_SHIFT_TIMEOUT;
     QS.osk_tap_toggle = ONESHOT_TAP_TOGGLE;
     QS.osk_timeout = ONESHOT_TIMEOUT;


### PR DESCRIPTION
Less elaborate version fixing autoshift conflicting with qmk settings https://github.com/vial-kb/vial-qmk/issues/765

See also https://github.com/vial-kb/vial-qmk/pull/225

