### PR TITLE
Enable split watchdog for Murcielago

### DIFF
--- a/keyboards/murcielago/rev1/config.h
+++ b/keyboards/murcielago/rev1/config.h
@@ -20,6 +20,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 /* split options, use EEPROM for side detection */
 #define EE_HANDS
 #define SPLIT_USB_DETECT
+#define SPLIT_WATCHDOG_ENABLE
 
 /*
  * Feature disable options


### PR DESCRIPTION
Fixes the board being unresponsive after reboots.