### PR TITLE
Add support for Keychron Q11 ISO encoder version

### DIFF
--- a/keyboards/keychron/q11/iso_encoder/keymaps/vial/config.h
+++ b/keyboards/keychron/q11/iso_encoder/keymaps/vial/config.h
@@ -1,0 +1,8 @@
+/* SPDX-License-Identifier: GPL-2.0-or-later */
+
+#pragma once
+
+#define VIAL_KEYBOARD_UID {0xA4, 0x1E, 0xA5, 0x3C, 0xCC, 0x66, 0x08, 0xCD}
+
+#define VIAL_UNLOCK_COMBO_ROWS { 0, 9 }
+#define VIAL_UNLOCK_COMBO_COLS { 1, 7 }

--- a/keyboards/keychron/q11/iso_encoder/keymaps/vial/keymap.c
+++ b/keyboards/keychron/q11/iso_encoder/keymaps/vial/keymap.c
@@ -1,0 +1,69 @@
+/* Copyright 2023 @ Keychron (https://www.keychron.com)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#include QMK_KEYBOARD_H
+
+enum layers{
+    MAC_BASE,
+    MAC_FN,
+    WIN_BASE,
+    WIN_FN,
+};
+
+#define KC_TASK LGUI(KC_TAB)
+#define KC_FLXP LGUI(KC_E)
+
+const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+    [MAC_BASE] = LAYOUT_92_iso(
+        KC_MUTE,  KC_ESC,   KC_BRID,  KC_BRIU,  KC_MCTL,  KC_LPAD,  RGB_VAD,   RGB_VAI,  KC_MPRV,  KC_MPLY,  KC_MNXT,  KC_MUTE,  KC_VOLD,    KC_VOLU,  KC_INS,   KC_DEL,   KC_MUTE,
+        _______,  KC_GRV,   KC_1,     KC_2,     KC_3,     KC_4,     KC_5,      KC_6,     KC_7,     KC_8,     KC_9,     KC_0,     KC_MINS,    KC_EQL,   KC_BSPC,            KC_PGUP,
+        _______,  KC_TAB,   KC_Q,     KC_W,     KC_E,     KC_R,     KC_T,      KC_Y,     KC_U,     KC_I,     KC_O,     KC_P,     KC_LBRC,    KC_RBRC,                      KC_PGDN,
+        _______,  KC_CAPS,  KC_A,     KC_S,     KC_D,     KC_F,     KC_G,      KC_H,     KC_J,     KC_K,     KC_L,     KC_SCLN,  KC_QUOT,    KC_NUHS,  KC_ENT,             KC_HOME,
+        _______,  KC_LSFT,  KC_NUBS,  KC_Z,     KC_X,     KC_C,     KC_V,      KC_B,     KC_N,     KC_M,     KC_COMM,  KC_DOT,   KC_SLSH,              KC_RSFT,  KC_UP,
+        _______,  KC_LCTL,  KC_LOPT,  KC_LCMD,  MO(MAC_FN),         KC_SPC,                        KC_SPC,             KC_RCMD,  MO(MAC_FN), KC_RCTL,  KC_LEFT,  KC_DOWN,  KC_RGHT),
+
+    [MAC_FN] = LAYOUT_92_iso(
+        RGB_TOG,  _______,  KC_F1,    KC_F2,    KC_F3,    KC_F4,    KC_F5,     KC_F6,    KC_F7,    KC_F8,    KC_F9,    KC_F10,   KC_F11,     KC_F12,   _______,  _______,  RGB_TOG,
+        _______,  _______,  _______,  _______,  _______,  _______,  _______,   _______,  _______,  _______,  _______,  _______,  _______,    _______,  _______,            _______,
+        _______,  RGB_TOG,  RGB_MOD,  RGB_VAI,  RGB_HUI,  RGB_SAI,  RGB_SPI,   _______,  _______,  _______,  _______,  _______,  _______,    _______,                      _______,
+        _______,  _______,  RGB_RMOD, RGB_VAD,  RGB_HUD,  RGB_SAD,  RGB_SPD,   _______,  _______,  _______,  _______,  _______,  _______,    _______,  _______,            _______,
+        _______,  _______,  _______,  _______,  _______,  _______,  _______,   _______,  NK_TOGG,  _______,  _______,  _______,  _______,              _______,  _______,
+        _______,  _______,  _______,  _______,  _______,            _______,                       _______,            _______,  _______,    _______,  _______,  _______,  _______),
+
+    [WIN_BASE] = LAYOUT_92_iso(
+        KC_MUTE,  KC_ESC,   KC_F1,    KC_F2,    KC_F3,    KC_F4,    KC_F5,     KC_F6,    KC_F7,    KC_F8,    KC_F9,    KC_F10,   KC_F11,     KC_F12,   KC_INS,   KC_DEL,   KC_MUTE,
+        _______,  KC_GRV,   KC_1,     KC_2,     KC_3,     KC_4,     KC_5,      KC_6,     KC_7,     KC_8,     KC_9,     KC_0,     KC_MINS,    KC_EQL,   KC_BSPC,            KC_PGUP,
+        _______,  KC_TAB,   KC_Q,     KC_W,     KC_E,     KC_R,     KC_T,      KC_Y,     KC_U,     KC_I,     KC_O,     KC_P,     KC_LBRC,    KC_RBRC,                      KC_PGDN,
+        _______,  KC_CAPS,  KC_A,     KC_S,     KC_D,     KC_F,     KC_G,      KC_H,     KC_J,     KC_K,     KC_L,     KC_SCLN,  KC_QUOT,    KC_NUHS,  KC_ENT,             KC_HOME,
+        _______,  KC_LSFT,  KC_NUBS,  KC_Z,     KC_X,     KC_C,     KC_V,      KC_B,     KC_N,     KC_M,     KC_COMM,  KC_DOT,   KC_SLSH,              KC_RSFT,  KC_UP,
+        _______,  KC_LCTL,  KC_LWIN,  KC_LALT,  MO(WIN_FN),         KC_SPC,                        KC_SPC,             KC_RALT,  MO(WIN_FN), KC_RCTL,  KC_LEFT,  KC_DOWN,  KC_RGHT),
+
+    [WIN_FN] = LAYOUT_92_iso(
+        RGB_TOG,  _______,  KC_BRID,  KC_BRIU,  KC_TASK,  KC_FLXP,  RGB_VAD,   RGB_VAI,  KC_MPRV,  KC_MPLY,  KC_MNXT,  KC_MUTE,  KC_VOLD,    KC_VOLU,  _______,  _______,  RGB_TOG,
+        _______,  _______,  _______,  _______,  _______,  _______,  _______,   _______,  _______,  _______,  _______,  _______,  _______,    _______,  _______,            _______,
+        _______,  RGB_TOG,  RGB_MOD,  RGB_VAI,  RGB_HUI,  RGB_SAI,  RGB_SPI,   _______,  _______,  _______,  _______,  _______,  _______,    _______,                      _______,
+        _______,  _______,  RGB_RMOD, RGB_VAD,  RGB_HUD,  RGB_SAD,  RGB_SPD,   _______,  _______,  _______,  _______,  _______,  _______,    _______,  _______,            _______,
+        _______,  _______,  _______,  _______,  _______,  _______,  _______,   _______,  NK_TOGG,  _______,  _______,  _______,  _______,              _______,  _______,
+        _______,  _______,  _______,  _______,  _______,            _______,                       _______,            _______,  _______,    _______,  _______,  _______,  _______),
+};
+
+#if defined(ENCODER_MAP_ENABLE)
+const uint16_t PROGMEM encoder_map[][NUM_ENCODERS][NUM_DIRECTIONS] = {
+    [MAC_BASE] = { ENCODER_CCW_CW(KC_VOLD, KC_VOLU), ENCODER_CCW_CW(KC_VOLD, KC_VOLU) },
+    [MAC_FN]   = { ENCODER_CCW_CW(RGB_VAD, RGB_VAI), ENCODER_CCW_CW(RGB_VAD, RGB_VAI) },
+    [WIN_BASE] = { ENCODER_CCW_CW(KC_VOLD, KC_VOLU), ENCODER_CCW_CW(KC_VOLD, KC_VOLU) },
+    [WIN_FN]   = { ENCODER_CCW_CW(RGB_VAD, RGB_VAI), ENCODER_CCW_CW(RGB_VAD, RGB_VAI) }
+};
+#endif // ENCODER_MAP_ENABLE

--- a/keyboards/keychron/q11/iso_encoder/keymaps/vial/rules.mk
+++ b/keyboards/keychron/q11/iso_encoder/keymaps/vial/rules.mk
@@ -1,0 +1,7 @@
+VIA_ENABLE = yes
+VIAL_ENABLE = yes
+VIALRGB_ENABLE = yes
+ENCODER_MAP_ENABLE = yes
+
+VPATH += keyboards/keychron/common
+SRC += keychron_common.c

--- a/keyboards/keychron/q11/iso_encoder/keymaps/vial/vial.json
+++ b/keyboards/keychron/q11/iso_encoder/keymaps/vial/vial.json
@@ -1,0 +1,312 @@
+{
+  "name": "Keychron Q11 ISO Knob",
+  "vendorId": "0x3434",
+  "productId": "0x01E1",
+  "lighting": "vialrgb",
+  "customKeycodes": [
+    {
+      "name": "Mission Control",
+      "title": "Mission Control in macOS",
+      "shortName": "MCtrl"
+    },
+    {
+      "name": "Launch Pad",
+      "title": "Launch Pad in macOS",
+      "shortName": "LPad"
+    },
+    {
+      "name": "Left Option",
+      "title": "Left Option in macOS",
+      "shortName": "LOpt"
+    },
+    {
+      "name": "Right Option",
+      "title": "Right Option in macOS",
+      "shortName": "ROpt"
+    },
+    {
+      "name": "Left Cmd",
+      "title": "Left Command in macOS",
+      "shortName": "LCmd"
+    },
+    {
+      "name": "Right Cmd",
+      "title": "Right Command in macOS",
+      "shortName": "RCmd"
+    },
+    {
+      "name": "Siri",
+      "title": "Siri in macOS",
+      "shortName": "Siri"
+    },
+    {
+      "name": "Task View",
+      "title": "Task View in windows",
+      "shortName": "Task"
+    },
+    {
+      "name": "File Explorer",
+      "title": "File Explorer in windows",
+      "shortName": "File"
+    },
+    {
+      "name": "Screen Shot",
+      "title": "Screenshot in macOS",
+      "shortName": "SShot"
+    },
+    {
+      "name": "Cortana",
+      "title": "Cortana in windows",
+      "shortName": "Cortana"
+    }
+  ],
+  "matrix": {"rows": 12, "cols": 9},
+  "layouts": {
+    "keymap": [
+      [
+          {
+              "x": 0.25
+          },
+          "0,0\n\n\n\n\n\n\n\n\ne",
+          "0,1\n\n\n\n\n\n\n\n\ne",
+          {
+              "x": 15
+          },
+          "1,0\n\n\n\n\n\n\n\n\ne",
+          "1,1\n\n\n\n\n\n\n\n\ne"
+      ],
+      [
+        {
+          "c": "#aaaaaa"
+        },
+        "0,0",
+        {
+          "x": 0.25,
+          "c": "#777777"
+        },
+        "0,1\nESC",
+        {
+          "c": "#cccccc"
+        },
+        "0,2",
+        "0,3",
+        "0,4",
+        "0,5",
+        {
+          "c": "#aaaaaa"
+        },
+        "0,6",
+        "0,7",
+        {
+          "x": 0.75
+        },
+        "6,0",
+        "6,1",
+        {
+          "c": "#cccccc"
+        },
+        "6,2",
+        "6,3",
+        "6,4",
+        "6,5",
+        {
+          "c": "#aaaaaa"
+        },
+        "6,6",
+        "6,7",
+        {
+          "x": 0.25
+        },
+        "6,8"
+      ],
+      [
+        {
+          "y": 0.25
+        },
+        "1,0",
+        {
+          "x": 0.25
+        },
+        "1,1",
+        {
+          "c": "#cccccc"
+        },
+        "1,2",
+        "1,3",
+        "1,4",
+        "1,5",
+        "1,6",
+        "1,7",
+        {
+          "x": 0.75
+        },
+        "7,0",
+        "7,1",
+        "7,2",
+        "7,3",
+        "7,4",
+        "7,5",
+        {
+          "c": "#aaaaaa",
+          "w": 2
+        },
+        "7,6",
+        {
+          "x": 0.25
+        },
+        "7,8"
+      ],
+      [
+        "2,0",
+        {
+          "x": 0.25,
+          "w": 1.5
+        },
+        "2,1",
+        {
+          "c": "#cccccc"
+        },
+        "2,2",
+        "2,3",
+        "2,4",
+        "2,6",
+        "2,7",
+        {
+          "x": 0.75
+        },
+        "8,0",
+        "8,1",
+        "8,2",
+        "8,3",
+        "8,4",
+        "8,5",
+        "8,6",
+        {
+          "x": 0.25,
+          "c": "#777777",
+          "w": 1.25,
+          "h": 2,
+          "w2": 1.5,
+          "h2": 1,
+          "x2": -0.25
+        },
+        "8,7",
+        {
+          "x": 0.25,
+          "c": "#aaaaaa"
+        },
+        "8,8"
+      ],
+      [
+        "3,0",
+        {
+          "x": 0.25,
+          "w": 1.75
+        },
+        "3,1",
+        {
+          "c": "#cccccc"
+        },
+        "3,2",
+        "3,3",
+        "3,4",
+        "3,5",
+        "3,6",
+        {
+          "x": 0.75
+        },
+        "9,0",
+        "9,1",
+        "9,2",
+        "9,3",
+        "9,4",
+        "9,5",
+        {
+          "c": "#aaaaaa"
+        },
+        "9,7",
+        {
+          "x": 1.5
+        },
+        "9,8"
+      ],
+      [
+        "4,0",
+        {
+          "x": 0.25,
+          "w": 1.25
+        },
+        "4,1",
+        "4,2",
+        {
+          "c": "#cccccc"
+        },
+        "4,3",
+        "4,4",
+        "4,5",
+        "4,6",
+        "4,7",
+        {
+          "x": 0.75
+        },
+        "10,0",
+        "10,1",
+        "10,2",
+        "10,3",
+        "10,4",
+        {
+          "c": "#aaaaaa",
+          "w": 1.75
+        },
+        "10,5",
+        {
+          "x": 0.25,
+          "c": "#777777"
+        },
+        "10,7"
+      ],
+      [
+        {
+          "c": "#aaaaaa"
+        },
+        "5,0",
+        {
+          "x": 0.25,
+          "w": 1.25
+        },
+        "5,1",
+        {
+          "w": 1.25
+        },
+        "5,2",
+        {
+          "w": 1.25
+        },
+        "5,3",
+        {
+          "w": 1.25
+        },
+        "5,4",
+        {
+          "w": 2.25
+        },
+        "5,6",
+        {
+          "x": 0.75,
+          "w": 2.75
+        },
+        "11,1",
+        "11,2",
+        "11,3",
+        "11,4",
+        {
+          "x": 0.25,
+          "c": "#777777"
+        },
+        "11,6",
+        "11,7",
+        "11,8"
+      ]
+    ]
+  }
+}


### PR DESCRIPTION
This adds support for the ISO version of the Keychron Q11 keyboard. Presently, only the ANSI layout version is supported by Vial, which this PR intends to fix.

It is based mostly on the corresponding layout from the main QMK repo, with Vial support added according to the porting guide, nothing fancy.

Encoders are also fully supported.