### PR TITLE
fix(ci): lock CLI version and upgrade checkout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
     - name: (actions) Checkout Vial repo
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         persist-credentials: false
 
@@ -28,13 +28,13 @@ jobs:
   build-default:
     name: Build default keymaps for Vial
     runs-on: ubuntu-latest
-    container: ghcr.io/qmk/qmk_cli
+    container: ghcr.io/qmk/qmk_cli@sha256:16c4916e95b99bf88d27b15aec8db409ee17265d1710287fde248c6666508966
     env:
       KEYMAP: default
 
     steps:
     - name: (actions) Checkout Vial repo
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         persist-credentials: false
         submodules: recursive
@@ -66,13 +66,13 @@ jobs:
   build-vial:
     name: Build Vial keymaps
     runs-on: ubuntu-latest
-    container: ghcr.io/qmk/qmk_cli
+    container: ghcr.io/qmk/qmk_cli@sha256:16c4916e95b99bf88d27b15aec8db409ee17265d1710287fde248c6666508966
     env:
       KEYMAP: vial
 
     steps:
     - name: (actions) Checkout Vial repo
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         persist-credentials: false
         submodules: recursive


### PR DESCRIPTION
- QMK CLI 1.1.6 upgrades to milc 1.9.0 which involves breaking changes; remain on 1.1.5 until fixes are merged in
- Upgrade to checkout@v4 to deal with node deprecation warnings