### PR TITLE
Add memory usage note for ut472

### DIFF
--- a/keyboards/keyhive/ut472/readme.md
+++ b/keyboards/keyhive/ut472/readme.md
@@ -18,3 +18,8 @@ To create a hex file for the UT47.2, run:
 Go to the [default layout README](keymaps/default/readme.md) for more information.
 
 See the [build environment setup](https://docs.qmk.fm/#/getting_started_build_tools) and the [make instructions](https://docs.qmk.fm/#/getting_started_make_guide) for more information. Brand new to QMK? Start with our [Complete Newbs Guide](https://docs.qmk.fm/#/newbs).
+
+## RGB Memory Usage
+If you are having unusual issues such as keys sticking (such as ctrl) then you may need to disable RGB animations to save on memory in [keyboard.json](keyboard.json).
+Setting rainbow_mood and rainbow_swirl to false for example allows for the keyboard to work well.
+See [Example Usage to Reduce Memory Footprint](https://docs.qmk.fm/features/rgblight#example-usage-to-reduce-memory-footprint) for more information.


### PR DESCRIPTION
ut472 can run into strange issues, such as ctrl key sticking after switching layers. turning off a couple of rgb animations helps with this issue. Adding a readme note in case others run into this issue.
