### PR TITLE
Fix typo in flash documentation

### DIFF
--- a/keyboards/keebart/sofle_choc_pro/readme.md
+++ b/keyboards/keebart/sofle_choc_pro/readme.md
@@ -25,6 +25,6 @@ See the [build environment setup](https://docs.qmk.fm/#/getting_started_build_to
 
 Enter the bootloader in 3 ways:
 
-* **Bootmagic reset**: Hold down the top left key of the left side of the keyboard while connecting the left side to the computer. Similarly, hold down the top left key of the right side of the keyboard while connecting the right side to the computer.
+* **Bootmagic reset**: Hold down the top left key of the left side of the keyboard while connecting the left side to the computer. Similarly, hold down the top right key of the right side of the keyboard while connecting the right side to the computer.
 * **Physical reset button**: Briefly press the button on the back of the PCB
 * **Keycode in layout**: Press the key mapped to `QK_BOOT` if it is available


### PR DESCRIPTION
Correct key when flashing right part of Sofle Choc Pro keyboard.

cc @trgsv 
