### PR TITLE
Config pwm backlight breath does not work in vial

### DIFF
--- a/platforms/chibios/drivers/backlight_pwm.c
+++ b/platforms/chibios/drivers/backlight_pwm.c
@@ -90,7 +90,7 @@ void backlight_init_ports(void) {
     pwmStart(&BACKLIGHT_PWM_DRIVER, &pwmCFG);
 
     backlight_set(get_backlight_level());
-
+    backlight_init();
 #ifdef BACKLIGHT_BREATHING
     chVTObjectInit(&breathing_vt);
     if (is_backlight_breathing()) {


### PR DESCRIPTION
Hi guys! I use stm32 microcontroller to diy a keyboard with vial-qmk firmware, and i suffer a problem that i think it maybe a bug.
I make a pwm driver backlight, when config backlight breath mode in vial, the config doesn't work when i restart keyboard, you can see this video.
[https://youtube.com/shorts/35hCvu_-iII?si=qNXDO0WwSzb6_Lbw](url) 
After i use this pull request code, build new firmware and test again, it works, as shown below video.
https://youtube.com/shorts/fodMocFwfG8?feature=share
So please help me to review this PR.
