### PR TITLE
Vial support for ploopyco trackball_thumb

### DIFF
--- a/keyboards/ploopyco/trackball_thumb/keymaps/vial/config.h
+++ b/keyboards/ploopyco/trackball_thumb/keymaps/vial/config.h
@@ -1,0 +1,8 @@
+/* SPDX-License-Identifier: GPL-2.0-or-later */
+
+#pragma once
+
+#define VIAL_KEYBOARD_UID {0xD1, 0x6A, 0xE9, 0x2A, 0xC4, 0xD0, 0x16, 0x35}
+
+#define VIAL_UNLOCK_COMBO_ROWS { 0, 0 }
+#define VIAL_UNLOCK_COMBO_COLS { 3, 5 }

--- a/keyboards/ploopyco/trackball_thumb/keymaps/vial/keymap.c
+++ b/keyboards/ploopyco/trackball_thumb/keymaps/vial/keymap.c
@@ -1,0 +1,25 @@
+/* Copyright 2021 Colin Lam (Ploopy Corporation)
+ * Copyright 2020 Christopher Courtney, aka Drashna Jael're  (@drashna) <drashna@live.com>
+ * Copyright 2019 Sunjun Kim
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#include QMK_KEYBOARD_H
+
+const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+    [0] = LAYOUT( /* Base */
+        KC_BTN4, KC_BTN1, KC_BTN3, KC_BTN2, KC_BTN5,
+        DPI_CONFIG
+    ),
+};

--- a/keyboards/ploopyco/trackball_thumb/keymaps/vial/rules.mk
+++ b/keyboards/ploopyco/trackball_thumb/keymaps/vial/rules.mk
@@ -1,0 +1,2 @@
+VIA_ENABLE = yes
+VIAL_ENABLE = yes

--- a/keyboards/ploopyco/trackball_thumb/keymaps/vial/rules.mk
+++ b/keyboards/ploopyco/trackball_thumb/keymaps/vial/rules.mk
@@ -1,2 +1,5 @@
 VIA_ENABLE = yes
 VIAL_ENABLE = yes
+LTO_ENABLE = yes
+QMK_SETTINGS = no
+

--- a/keyboards/ploopyco/trackball_thumb/keymaps/vial/vial.json
+++ b/keyboards/ploopyco/trackball_thumb/keymaps/vial/vial.json
@@ -1,0 +1,59 @@
+{
+  "name": "PloopyCo Trackball Thumb",
+  "vendorId": "0x5043",
+  "productId": "0x5C46",
+  "matrix": {
+    "rows": 1,
+    "cols": 6
+  },
+  "customKeycodes": [
+    {
+      "name": "DPI Config",
+      "title": "DPI Config",
+      "shortName": "DPI"
+    },
+    {
+      "name": "Drag Scroll",
+      "title": "Drag Scroll",
+      "shortName": "DragScl"
+    }
+  ],
+  "lighting": "none",
+  "layouts": {
+    "keymap": [
+      [
+        "0,0",
+        {
+          "h": 2
+        },
+        "0,2",
+        {
+          "x": 1,
+          "h": 2
+        },
+        "0,4"
+      ],
+      [
+        {
+          "y": -0.75,
+          "x": 2,
+          "h": 1.5
+        },
+        "0,3"
+      ],
+      [
+        {
+          "y": -0.75,
+          "x": 4
+        },
+        "0,5"
+      ],
+      [
+        {
+          "y": -0.5
+        },
+        "0,1"
+      ]
+    ]
+  }
+}


### PR DESCRIPTION
- Added vial keymap using the qmk default
- created vial.json from the via repository
- created config.h with unique UID
- included some optimizations in rules.mk to reduce firmware size

I have only tested on rev1_001, but I have not seen any unique keymaps for rev1_002 so I assume this will work for both.