### PR TITLE
feat: Add vial support for Epomaker Tide65 keyboard

### DIFF
--- a/keyboards/epomaker/tide65/keymaps/vial/config.h
+++ b/keyboards/epomaker/tide65/keymaps/vial/config.h
@@ -1,0 +1,8 @@
+/* SPDX-License-Identifier: GPL-2.0-or-later */
+
+#pragma once
+
+#define VIAL_UNLOCK_COMBO_ROWS { 0, 2 }
+#define VIAL_UNLOCK_COMBO_COLS { 0, 13 }
+
+#define VIAL_KEYBOARD_UID {0x31, 0xA0, 0x1B, 0xB6, 0x9D, 0xE0, 0x6D, 0xB2}

--- a/keyboards/epomaker/tide65/keymaps/vial/keymap.c
+++ b/keyboards/epomaker/tide65/keymaps/vial/keymap.c
@@ -1,0 +1,26 @@
+// Copyright 2024 SDK (@sdk66)
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include QMK_KEYBOARD_H
+
+// clang-format off
+const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+
+    [0] = LAYOUT( /* Base */
+        KC_ESC,   KC_1,       KC_2,       KC_3,     KC_4,     KC_5,     KC_6,     KC_7,     KC_8,     KC_9,     KC_0,       KC_MINS,  KC_EQL,   KC_BSPC,   KC_MUTE,
+        KC_TAB,   KC_Q,       KC_W,       KC_E,     KC_R,     KC_T,     KC_Y,     KC_U,     KC_I,     KC_O,     KC_P,       KC_LBRC,  KC_RBRC,  KC_BSLS,   KC_DEL,
+        KC_CAPS,  KC_A,       KC_S,       KC_D,     KC_F,     KC_G,     KC_H,     KC_J,     KC_K,     KC_L,     KC_SCLN,    KC_QUOT,            KC_ENT,    KC_PGUP,  
+        KC_LSFT,  KC_Z,       KC_X,       KC_C,     KC_V,     KC_B,     KC_N,     KC_M,     KC_COMM,  KC_DOT,               KC_SLSH,  KC_RSFT,  KC_UP,     KC_PGDN,
+        KC_LCTL,  KC_LGUI,    KC_LALT,    KC_SPC,   KC_SPC,   KC_SPC,   KC_SPC,                       KC_RALT,              MO(1),    KC_LEFT,  KC_DOWN,   KC_RGHT
+        ),  
+
+    [1] = LAYOUT( /* Base */
+        KC_GRV,   KC_F1,      KC_F2,      KC_F3,    KC_F4,    KC_F5,    KC_F6,    KC_F7,    KC_F8,    KC_F9,    KC_F10,     KC_F11,   KC_F12,   _______,   _______,
+        _______,  _______,    _______,    _______,  _______,  _______,  _______,  _______,  _______,  _______,  _______,    KC_HOME,  KC_SCRL,  _______,   _______,
+        _______,  _______,    _______,    _______,  _______,  _______,  _______,  _______,  _______,  _______,  _______,    KC_PSCR,            _______,   _______,
+        _______,  _______,    _______,    _______,  _______,  _______,  _______,  _______,  _______,  _______,              _______,  _______,  _______,   _______,
+        _______,  GU_TOGG,    _______,    EE_CLR,   EE_CLR,   EE_CLR,   EE_CLR,                       _______,              _______,  _______,  _______,   _______
+        )
+};
+
+// clang-format on

--- a/keyboards/epomaker/tide65/keymaps/vial/rules.mk
+++ b/keyboards/epomaker/tide65/keymaps/vial/rules.mk
@@ -1,0 +1,3 @@
+VIA_ENABLE = yes
+VIAL_ENABLE = yes
+

--- a/keyboards/epomaker/tide65/keymaps/vial/rules.mk
+++ b/keyboards/epomaker/tide65/keymaps/vial/rules.mk
@@ -1,3 +1,5 @@
 VIA_ENABLE = yes
 VIAL_ENABLE = yes
 
+
+

--- a/keyboards/epomaker/tide65/keymaps/vial/vial.json
+++ b/keyboards/epomaker/tide65/keymaps/vial/vial.json
@@ -1,0 +1,248 @@
+{
+  "name": "EPOMAKER TIDE 65",
+  "vendorId": "0x342d",
+  "productId": "0xe463",
+  "keycodes": ["qmk_lighting"],
+  "menus": [
+    {
+      "label": "Lighting",
+      "content": [
+        {
+          "label": "Backlight",
+          "content": [
+            {
+              "label": "Brightness",
+              "type": "range",
+              "options": [0, 255],
+              "content": ["id_qmk_rgb_matrix_brightness", 3, 1]
+            },
+            {
+              "label": "Effect",
+              "type": "dropdown",
+              "content": ["id_qmk_rgb_matrix_effect", 3, 2],
+              "options": [
+                ["All Off", 0],
+                ["Solid Color", 1],
+                ["Alphas Mods", 2],
+                ["Gradient Up Down", 3],
+                ["Gradient Left Right", 4],
+                ["Breathing", 5],
+                ["Band Sat", 6],
+                ["Band Val", 7],
+                ["Band Pinwheel Sat", 8],
+                ["Band Pinwheel Val", 9],
+                ["Band Spiral Sat", 10],
+                ["Band Spiral Val", 11],
+                ["Cycle All", 12],
+                ["Cycle Left Right", 13],
+                ["Cycle Up Down", 14],
+                ["Rainbow Moving Chevron", 15],
+                ["Cycle Out In", 16],
+                ["Cycle Out In Dual", 17],
+                ["Cycle Pinwheel", 18],
+                ["Cycle Spiral", 19],
+                ["Dual Beacon", 20],
+                ["Rainbow Beacon", 21],
+                ["Rainbow Pinwheels", 22],
+                ["Raindrops", 23],
+                ["Jellybean Raindrops", 24],
+                ["Hue Breathing", 25],
+                ["Hue Pendulum", 26],
+                ["Hue Wave", 27],
+                ["Pixel Rain", 28],
+                ["Pixel Flow", 29],
+                ["Pixel Fractal", 30],
+                ["Typing Heatmap", 31],
+                ["Digital Rain", 32],
+                ["Solid Reactive Simple", 33],
+                ["Solid Reactive", 34],
+                ["Solid Reactive Wide", 35],
+                ["Solid Reactive Multiwide", 36],
+                ["Solid Reactive Cross", 37],
+                ["Solid Reactive Multicross", 38],
+                ["Solid Reactive Nexus", 39],
+                ["Solid Reactive Multinexus", 40],
+                ["Splash", 41],
+                ["Multisplash", 42],
+                ["Solid Splash", 43],
+                ["Solid Multisplash", 44],
+                ["Close All", 45]
+              ]
+            },
+            {
+              "showIf": "{id_qmk_rgb_matrix_effect} != 0",
+              "label": "Effect Speed",
+              "type": "range",
+              "options": [0, 255],
+              "content": ["id_qmk_rgb_matrix_effect_speed", 3, 3]
+            },
+            {
+              "showIf": "{id_qmk_rgb_matrix_effect} != 0 && {id_qmk_rgb_matrix_effect} != 24 && {id_qmk_rgb_matrix_effect} != 28 && {id_qmk_rgb_matrix_effect} != 29 && {id_qmk_rgb_matrix_effect} != 32",
+              "label": "Color",
+              "type": "color",
+              "content": ["id_qmk_rgb_matrix_color", 3, 4]
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "matrix": {"rows": 5, "cols": 15},
+  "customKeycodes": [
+    {"name": "BT1",  "title": "BT1",   "shortName": "BT1"},
+    {"name": "BT2",  "title": "BT2",   "shortName": "BT2"},
+    {"name": "BT3",  "title": "BT3",   "shortName": "BT3"},
+    {"name": "",   "title": "", "shortName": ""},
+    {"name": "L_TOG",   "title": "L_TOG", "shortName": "L_TOG"},
+    {"name": "2G4",  "title": "IM_2G4",   "shortName": "2G4"},
+    {"name": "USB",  "title": "IM_USB",   "shortName": "USB"},
+    {"name": "IM_BATQ", "title": "BATQ",  "shortName": "BATQ"}
+  ],
+  "layouts": {
+    "presets": {"Default": [0,0]},
+    "labels": [
+      ["Space selection", "Split spaces", "Long spaces"]
+    ],
+      "keymap":
+      [
+        [
+          "0,0\n`",
+          "0,1\n1",
+          "0,2\n2",
+          "0,3\n3",
+          "0,4\n4",
+          "0,5\n5",
+          "0,6\n6",
+          "0,7\n7",
+          "0,8\n8",
+          "0,9\n9",
+          "0,10\n0",
+          "0,11\n-",
+          "0,12\n=",
+          {
+            "f": 2,
+            "w": 2
+          },
+          "0,13",
+          {
+            "f": 3
+          },
+          "0,14\n\n\n\n\n\n\n\n\ne0"
+        ],
+        [
+          {
+            "w": 1.5
+          },
+          "1,0",
+          "1,1",
+          "1,2",
+          "1,3",
+          "1,4",
+          "1,5",
+          "1,6",
+          "1,7",
+          "1,8",
+          "1,9",
+          "1,10",
+          "1,11\n[",
+          "1,12\n]",
+          {
+            "w": 1.5
+          },
+          "1,13\n#",
+          "1,14"
+        ],
+        [
+          {
+            "w": 1.75
+          },
+          "2,0",
+          "2,1",
+          "2,2",
+          "2,3",
+          "2,4",
+          "2,5",
+          "2,6",
+          "2,7",
+          "2,8",
+          "2,9",
+          "2,10\n;",
+          "2,11\n'",
+          {
+            "w": 2.25
+          },
+          "2,13",
+          "2,14"
+        ],
+        [
+          {
+            "w": 2.25
+          },
+          "3,0",
+          "3,1",
+          "3,2",
+          "3,3",
+          "3,4",
+          "3,5",
+          "3,6",
+          "3,7",
+          "3,8\n,",
+          "3,9\n.",
+          "3,11\n/",
+          {
+            "w": 1.75
+          },
+          "3,12",
+          "3,13",
+          "3,14"
+        ],
+        [
+          {
+            "w": 1.25
+          },
+          "4,0",
+          {
+            "w": 1.25
+          },
+          "4,1",
+          {
+            "w": 1.25
+          },
+          "4,2",
+          {
+            "w": 2.25
+          },
+          "4,3\n\n\n0,0",
+          {
+            "w": 1.25
+          },
+          "4,4\n\n\n0,0",
+          {
+            "w": 2.75
+          },
+          "4,6\n\n\n0,0",
+          {
+            "w": 1.25
+          },
+          "4,9",
+          {
+            "w": 1.25
+          },
+          "4,11",
+          {
+            "x": 0.5
+          },
+          "4,12",
+          "4,13",
+          "4,14"
+        ],
+        [
+          {
+            "x": 3.75,
+            "w": 6.25
+          },
+          "4,5\n\n\n0,1"
+        ]
+      ]
+  }
+}


### PR DESCRIPTION
<!---

    If you are submitting a Vial-enabled keymap for a keyboard in QMK:

    - Keymaps will not be accepted with VIAL_INSECURE=yes.
    - Avoid changing keyboard-level code if possible. (ex: switching the encoder pins in info.json)
    - Please name your keymap "vial". Personal keymaps are not accepted at this time.
      - If your Vial keymap only works for a specific keyboard revision, place it under that revision's folder. (ex: keyboards/planck/rev6_drop/keymaps/vial and keyboards/planck/ez/glow/keymaps/vial)

    If you are submitting a new keyboard with keymaps:

    - If you are also submitting this keyboard to QMK, please try to submit mostly the same code to both repos if possible.
    - If you are not submitting this keyboard to QMK, only include "default" and "vial" keymaps. VIA firmware can no longer be built by this repository.

    ------

    For all keyboard and keymap submissions:

    As the submitter, you are ultimately responsible for maintaining the keyboards/keymaps you submit.
    Vial contributors will try to fix compilation issues as updates are made, but are not always familiar with and often can't test specific keymaps/keyboards.

    Vial is decentralized, so inclusion in the vial-qmk repository is optional. Unmaintained keymaps/keyboards which are broken and cannot be fixed without extensive rework or strong familiarity with the hardware may be removed from this repository, with or without warning.

    ------

    For core changes, please explain what you are changing and why.

    Before submitting a PR, delete the entirety of this comment and document your changes.
-->
