### PR TITLE
Fix Monsgeek M3 RGB

### DIFF
--- a/keyboards/monsgeek/m3/keymaps/vial/rules.mk
+++ b/keyboards/monsgeek/m3/keymaps/vial/rules.mk
@@ -1,2 +1,3 @@
 VIA_ENABLE = yes
 VIAL_ENABLE = yes
+VIALRGB_ENABLE = yes

--- a/keyboards/monsgeek/m3/keymaps/vial/vial.json
+++ b/keyboards/monsgeek/m3/keymaps/vial/vial.json
@@ -2,7 +2,7 @@
     "name": "MonsGeek M3",
     "vendorId": "0xFFFE",
     "productId": "0x0009",
-    "lightning": "qmk_backlight",
+    "lighting": "vialrgb",
     "matrix": {
         "rows": 6,
         "cols": 17


### PR DESCRIPTION
The Monsgeek M3 RGB configuration was fixed:

- "Lightning" -> "Lighting" in the vial.json file, and the option set to `vialrgb`.
- Added `VIALRGB_ENABLE = yes` to vial.json.