### PR TITLE
Splitkb Elora Rev1 LTO fix

### DIFF
--- a/keyboards/splitkb/elora/keymaps/vial/rules.mk
+++ b/keyboards/splitkb/elora/keymaps/vial/rules.mk
@@ -1,8 +1,6 @@
 # Copyright 2024 splitkb.com (support@splitkb.com)
 # SPDX-License-Identifier: GPL-2.0-or-later
 
-LTO_ENABLE = no
-
 ## Vial-specific settings
 
 VIA_ENABLE = yes


### PR DESCRIPTION
Disabling LTO for the Splitkb Elora causes some undesired behaviors with the latest vial upstream, such as unresponsive keyboard and random rebooting. Keeping it enabled (as defined on the keyboard level) fixes these issues. This fix has been tested on an Elora rev1.
