### PR TITLE
Add Vial support for the NK65 base (v1.0-v1.3) revision keyboard.

### DIFF
--- a/keyboards/novelkeys/nk65/keymaps/vial/config.h
+++ b/keyboards/novelkeys/nk65/keymaps/vial/config.h
@@ -1,0 +1,8 @@
+/* SPDX-License-Identifier: GPL-2.0-or-later */
+
+#pragma once
+
+#define VIAL_KEYBOARD_UID {0x9A, 0x3E, 0x7B, 0x4C, 0x5D, 0x6F, 0x8E, 0x1A}
+
+#define VIAL_UNLOCK_COMBO_ROWS { 0, 2 }
+#define VIAL_UNLOCK_COMBO_COLS { 0, 13 }

--- a/keyboards/novelkeys/nk65/keymaps/vial/keymap.c
+++ b/keyboards/novelkeys/nk65/keymaps/vial/keymap.c
@@ -1,0 +1,46 @@
+/* Copyright 2019 Yiancar
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#include QMK_KEYBOARD_H
+
+const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+[0] = LAYOUT_65_ansi( /* Base */
+    QK_GESC, KC_1,    KC_2,   KC_3,   KC_4,   KC_5,   KC_6,   KC_7,   KC_8,    KC_9,    KC_0,    KC_MINS, KC_EQL,  KC_BSPC, KC_HOME,
+    KC_TAB,  KC_Q,    KC_W,   KC_E,   KC_R,   KC_T,   KC_Y,   KC_U,   KC_I,    KC_O,    KC_P,    KC_LBRC, KC_RBRC, KC_BSLS, KC_PGUP,
+    KC_CAPS, KC_A,    KC_S,   KC_D,   KC_F,   KC_G,   KC_H,   KC_J,   KC_K,    KC_L,    KC_SCLN, KC_QUOT,          KC_ENT,  KC_PGDN,
+    KC_LSFT, KC_Z,    KC_X,   KC_C,   KC_V,   KC_B,   KC_N,   KC_M,   KC_COMM, KC_DOT,  KC_SLSH, KC_RSFT,          KC_UP,   KC_END,
+    KC_LCTL, KC_LGUI, KC_LALT,                KC_SPC,                          KC_RALT, MO(1),   KC_RCTL, KC_LEFT, KC_DOWN, KC_RGHT),
+
+[1] = LAYOUT_65_ansi( /* FN */
+    KC_GRV,  KC_F1,   KC_F2,   KC_F3,   KC_F4,   KC_F5,   KC_F6,   KC_F7,   KC_F8,   KC_F9,   KC_F10,  KC_F11,  KC_F12,  KC_DEL,  KC_TRNS,
+    KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, QK_BOOT, KC_TRNS,
+    KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, S1_DEC,  S1_INC,  S2_DEC,  S2_INC,  KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS,          KC_TRNS, KC_TRNS,
+    KC_TRNS, EF_DEC,  EF_INC,  H1_DEC,  H1_INC,  H2_DEC,  H2_INC,  BR_DEC,  BR_INC,  ES_DEC,  ES_INC,  KC_TRNS,          KC_TRNS, KC_TRNS,
+    KC_VOLU, KC_VOLD, KC_MUTE,                KC_TRNS,                               KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS),
+
+[2] = LAYOUT_65_ansi( /* Empty for dynamic keymaps */
+    KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS,
+    KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS,
+    KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS,          KC_TRNS, KC_TRNS,
+    KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS,          KC_TRNS, KC_TRNS,
+    KC_TRNS, KC_TRNS, KC_TRNS,                KC_TRNS,                               KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS),
+
+[3] = LAYOUT_65_ansi( /* Empty for dynamic keymaps */
+    KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS,
+    KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS,
+    KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS,          KC_TRNS, KC_TRNS,
+    KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS,          KC_TRNS, KC_TRNS,
+    KC_TRNS, KC_TRNS, KC_TRNS,                KC_TRNS,                               KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS),
+};

--- a/keyboards/novelkeys/nk65/keymaps/vial/readme.md
+++ b/keyboards/novelkeys/nk65/keymaps/vial/readme.md
@@ -1,0 +1,40 @@
+# Vial Support for NK65 Entry Edition
+
+This keymap adds Vial support to the NK65 v1.0-v1.3 revision keyboard.
+
+## Features
+
+-   Full Vial support for dynamic keymap editing
+-   Wilba.tech RGB backlight controls (brightness, effects, colors, speed)
+-   VIA compatibility
+-   4 configurable layers
+
+## Default RGB Control Keys (Layer 1)
+
+-   **Z/X**: Change effect (EF_DEC/EF_INC)
+-   **C/V**: Adjust Color 1 Hue (H1_DEC/H1_INC)
+-   **B/N**: Adjust Color 2 Hue (H2_DEC/H2_INC)
+-   **M/,**: Adjust Brightness (BR_DEC/BR_INC)
+-   **./Slash**: Adjust Effect Speed (ES_DEC/ES_INC)
+-   **F/G**: Adjust Color 1 Saturation (S1_DEC/S1_INC)
+-   **T/Y**: Adjust Color 2 Saturation (S2_DEC/S2_INC)
+
+## Build
+
+    make novelkeys/nk65:vial
+
+## Flash
+
+To flash the firmware:
+
+1. Unplug the keyboard
+2. Hold Escape
+3. Plug in the keyboard (while still holding Escape)
+4. The keyboard will enter bootloader mode
+5. Flash using QMK Toolbox or: `make novelkeys/nk65:vial:flash`
+
+## Notes
+
+-   This keymap uses standard USB endpoints for optimal latency
+-   For macOS Globe key support with shared USB endpoints, use the `vial_globe` keymap instead
+-   RGB keycodes appear in the "User" section of the Vial configurator

--- a/keyboards/novelkeys/nk65/keymaps/vial/rules.mk
+++ b/keyboards/novelkeys/nk65/keymaps/vial/rules.mk
@@ -1,0 +1,3 @@
+VIA_ENABLE = yes
+VIAL_ENABLE = yes
+LTO_ENABLE = yes

--- a/keyboards/novelkeys/nk65/keymaps/vial/vial.json
+++ b/keyboards/novelkeys/nk65/keymaps/vial/vial.json
@@ -1,0 +1,45 @@
+{
+    "name": "NK65 Entry Edition",
+    "vendorId": "0x8968",
+    "productId": "0x4E4B",
+    "lighting": "wt_rgb_backlight",
+    "matrix": {
+        "rows": 5,
+        "cols": 15
+    },
+    "customKeycodes": [
+        {"name": "Brightness +", "title": "Brightness Increase", "shortName": "BR_INC"},
+        {"name": "Brightness -", "title": "Brightness Decrease", "shortName": "BR_DEC"},
+        {"name": "Effect +", "title": "Effect Increase", "shortName": "EF_INC"},
+        {"name": "Effect -", "title": "Effect Decrease", "shortName": "EF_DEC"},
+        {"name": "Effect Speed +", "title": "Effect Speed Increase", "shortName": "ES_INC"},
+        {"name": "Effect Speed -", "title": "Effect Speed Decrease", "shortName": "ES_DEC"},
+        {"name": "Color 1 Hue +", "title": "Color 1 Hue Increase", "shortName": "H1_INC"},
+        {"name": "Color 1 Hue -", "title": "Color 1 Hue Decrease", "shortName": "H1_DEC"},
+        {"name": "Color 1 Sat +", "title": "Color 1 Saturation Increase", "shortName": "S1_INC"},
+        {"name": "Color 1 Sat -", "title": "Color 1 Saturation Decrease", "shortName": "S1_DEC"},
+        {"name": "Color 2 Hue +", "title": "Color 2 Hue Increase", "shortName": "H2_INC"},
+        {"name": "Color 2 Hue -", "title": "Color 2 Hue Decrease", "shortName": "H2_DEC"},
+        {"name": "Color 2 Sat +", "title": "Color 2 Saturation Increase", "shortName": "S2_INC"},
+        {"name": "Color 2 Sat -", "title": "Color 2 Saturation Decrease", "shortName": "S2_DEC"}
+    ],
+    "layouts": {
+        "keymap": [
+            [
+                "0,0", "0,1", "0,2", "0,3", "0,4", "0,5", "0,6", "0,7", "0,8", "0,9", "0,10", "0,11", "0,12", {"w": 2}, "0,13", "0,14"
+            ],
+            [
+                {"w": 1.5}, "1,0", "1,1", "1,2", "1,3", "1,4", "1,5", "1,6", "1,7", "1,8", "1,9", "1,10", "1,11", "1,12", {"w": 1.5}, "2,12", "1,14"
+            ],
+            [
+                {"w": 1.75}, "2,0", "2,1", "2,2", "2,3", "2,4", "2,5", "2,6", "2,7", "2,8", "2,9", "2,10", "2,11", {"w": 2.25}, "2,13", "2,14"
+            ],
+            [
+                {"w": 2.25}, "3,0", "3,2", "3,3", "3,4", "3,5", "3,6", "3,7", "3,8", "3,9", "3,10", "3,11", {"w": 1.75}, "3,12", "3,13", "3,14"
+            ],
+            [
+                {"w": 1.25}, "4,0", {"w": 1.25}, "4,1", {"w": 1.25}, "4,2", {"w": 6.25}, "4,6", "4,9", "4,10", "4,11", "4,12", "4,13", "4,14"
+            ]
+        ]
+    }
+}

--- a/keyboards/novelkeys/nk65/keymaps/vial_globe/config.h
+++ b/keyboards/novelkeys/nk65/keymaps/vial_globe/config.h
@@ -1,0 +1,8 @@
+/* SPDX-License-Identifier: GPL-2.0-or-later */
+
+#pragma once
+
+#define VIAL_KEYBOARD_UID {0x9A, 0x3E, 0x7B, 0x4C, 0x5D, 0x6F, 0x8E, 0x1A}
+
+#define VIAL_UNLOCK_COMBO_ROWS { 0, 2 }
+#define VIAL_UNLOCK_COMBO_COLS { 0, 13 }

--- a/keyboards/novelkeys/nk65/keymaps/vial_globe/keymap.c
+++ b/keyboards/novelkeys/nk65/keymaps/vial_globe/keymap.c
@@ -1,0 +1,62 @@
+/* Copyright 2019 Yiancar
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#include QMK_KEYBOARD_H
+
+// Custom keycodes for Vial
+enum custom_keycodes {
+    GLOBE = QK_KB_14  // macOS Globe/Fn key (after the 14 RGB keycodes)
+};
+
+const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+[0] = LAYOUT_65_ansi( /* Base */
+    QK_GESC, KC_1,    KC_2,   KC_3,   KC_4,   KC_5,   KC_6,   KC_7,   KC_8,    KC_9,    KC_0,    KC_MINS, KC_EQL,  KC_BSPC, KC_HOME,
+    KC_TAB,  KC_Q,    KC_W,   KC_E,   KC_R,   KC_T,   KC_Y,   KC_U,   KC_I,    KC_O,    KC_P,    KC_LBRC, KC_RBRC, KC_BSLS, KC_PGUP,
+    KC_CAPS, KC_A,    KC_S,   KC_D,   KC_F,   KC_G,   KC_H,   KC_J,   KC_K,    KC_L,    KC_SCLN, KC_QUOT,          KC_ENT,  KC_PGDN,
+    KC_LSFT, KC_Z,    KC_X,   KC_C,   KC_V,   KC_B,   KC_N,   KC_M,   KC_COMM, KC_DOT,  KC_SLSH, KC_RSFT,          KC_UP,   KC_END,
+    KC_LCTL, KC_LGUI, KC_LALT,                KC_SPC,                          KC_RALT, MO(1),   KC_RCTL, KC_LEFT, KC_DOWN, KC_RGHT),
+
+[1] = LAYOUT_65_ansi( /* FN */
+    KC_GRV,  KC_F1,   KC_F2,   KC_F3,   KC_F4,   KC_F5,   KC_F6,   KC_F7,   KC_F8,   KC_F9,   KC_F10,  KC_F11,  KC_F12,  KC_DEL,  KC_TRNS,
+    KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, QK_BOOT, KC_TRNS,
+    KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, S1_DEC,  S1_INC,  S2_DEC,  S2_INC,  KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS,          KC_TRNS, KC_TRNS,
+    KC_TRNS, EF_DEC,  EF_INC,  H1_DEC,  H1_INC,  H2_DEC,  H2_INC,  BR_DEC,  BR_INC,  ES_DEC,  ES_INC,  KC_TRNS,          KC_TRNS, KC_TRNS,
+    KC_VOLU, KC_VOLD, KC_MUTE,                KC_TRNS,                               KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS),
+
+[2] = LAYOUT_65_ansi( /* Empty for dynamic keymaps */
+    KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS,
+    KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS,
+    KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS,          KC_TRNS, KC_TRNS,
+    KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS,          KC_TRNS, KC_TRNS,
+    KC_TRNS, KC_TRNS, KC_TRNS,                KC_TRNS,                               KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS),
+
+[3] = LAYOUT_65_ansi( /* Empty for dynamic keymaps */
+    KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS,
+    KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS,
+    KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS,          KC_TRNS, KC_TRNS,
+    KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS,          KC_TRNS, KC_TRNS,
+    KC_TRNS, KC_TRNS, KC_TRNS,                KC_TRNS,                               KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS),
+};
+
+bool process_record_user(uint16_t keycode, keyrecord_t *record) {
+    switch (keycode) {
+        case GLOBE:
+            // Send Globe key as consumer control (0x029D - AC Keyboard Layout Select)
+            // Based on: https://skip.house/blog/qmk-globe-key
+            host_consumer_send(record->event.pressed ? 0x029D : 0);
+            return false;
+    }
+    return true;
+}

--- a/keyboards/novelkeys/nk65/keymaps/vial_globe/readme.md
+++ b/keyboards/novelkeys/nk65/keymaps/vial_globe/readme.md
@@ -1,0 +1,56 @@
+# Vial Support for NK65 Entry Edition (with macOS Globe Key)
+
+This keymap adds Vial support with macOS Globe key functionality to the NK65 v1.0-v1.3 keyboard.
+
+## Features
+
+-   Full Vial support for dynamic keymap editing
+-   Wilba.tech RGB backlight controls (brightness, effects, colors, speed)
+-   VIA compatibility
+-   4 configurable layers
+-   **macOS Globe key support** - assignable custom keycode for Globe/Fn functionality
+
+## macOS Globe Key
+
+This keymap includes a custom "Globe" keycode that can be assigned to any key through the Vial configurator. The Globe key enables macOS-specific shortcuts such as:
+
+-   **Globe + E**: Emoji picker
+-   **Globe + C**: Control Center
+-   **Globe + N**: Opens Notifications
+-   **Globe + H**: Shows/Hides Desktop
+-   **Globe + M**: Navigate menu bar with arrow keys
+-   **Globe + A**: Navigate dock with arrow keys
+-   Others, but likely not all.
+
+The Globe keycode appears in the "User" section of the Vial configurator.
+
+## Default RGB Control Keys (Layer 1)
+
+-   **Z/X**: Change effect (EF_DEC/EF_INC)
+-   **C/V**: Adjust Color 1 Hue (H1_DEC/H1_INC)
+-   **B/N**: Adjust Color 2 Hue (H2_DEC/H2_INC)
+-   **M/,**: Adjust Brightness (BR_DEC/BR_INC)
+-   **./Slash**: Adjust Effect Speed (ES_DEC/ES_INC)
+-   **F/G**: Adjust Color 1 Saturation (S1_DEC/S1_INC)
+-   **T/Y**: Adjust Color 2 Saturation (S2_DEC/S2_INC)
+
+## Build
+
+    make novelkeys/nk65:vial_globe
+
+## Flash
+
+To flash the firmware:
+
+1. Unplug the keyboard
+2. Hold Escape
+3. Plug in the keyboard (while still holding Escape)
+4. The keyboard will enter bootloader mode
+5. Flash using QMK Toolbox or: `make novelkeys/nk65:vial_globe:flash`
+
+## Notes
+
+-   This keymap uses shared USB endpoints (`KEYBOARD_SHARED_EP = yes`) to enable Globe key functionality
+-   Shared endpoints allow both regular keypresses and consumer control codes (like Globe key) to be sent together
+-   In case of unexpected behavior, use the vial keymap instead for standard Vial support without Globe key or shared mode
+-   RGB keycodes and Globe keycode appear in the "User" section of the Vial configurator

--- a/keyboards/novelkeys/nk65/keymaps/vial_globe/rules.mk
+++ b/keyboards/novelkeys/nk65/keymaps/vial_globe/rules.mk
@@ -1,0 +1,4 @@
+VIA_ENABLE = yes
+VIAL_ENABLE = yes
+LTO_ENABLE = yes
+KEYBOARD_SHARED_EP = yes

--- a/keyboards/novelkeys/nk65/keymaps/vial_globe/vial.json
+++ b/keyboards/novelkeys/nk65/keymaps/vial_globe/vial.json
@@ -1,0 +1,46 @@
+{
+    "name": "NK65 Entry Edition",
+    "vendorId": "0x8968",
+    "productId": "0x4E4B",
+    "lighting": "wt_rgb_backlight",
+    "matrix": {
+        "rows": 5,
+        "cols": 15
+    },
+    "customKeycodes": [
+        {"name": "Brightness +", "title": "Brightness Increase", "shortName": "BR_INC"},
+        {"name": "Brightness -", "title": "Brightness Decrease", "shortName": "BR_DEC"},
+        {"name": "Effect +", "title": "Effect Increase", "shortName": "EF_INC"},
+        {"name": "Effect -", "title": "Effect Decrease", "shortName": "EF_DEC"},
+        {"name": "Effect Speed +", "title": "Effect Speed Increase", "shortName": "ES_INC"},
+        {"name": "Effect Speed -", "title": "Effect Speed Decrease", "shortName": "ES_DEC"},
+        {"name": "Color 1 Hue +", "title": "Color 1 Hue Increase", "shortName": "H1_INC"},
+        {"name": "Color 1 Hue -", "title": "Color 1 Hue Decrease", "shortName": "H1_DEC"},
+        {"name": "Color 1 Sat +", "title": "Color 1 Saturation Increase", "shortName": "S1_INC"},
+        {"name": "Color 1 Sat -", "title": "Color 1 Saturation Decrease", "shortName": "S1_DEC"},
+        {"name": "Color 2 Hue +", "title": "Color 2 Hue Increase", "shortName": "H2_INC"},
+        {"name": "Color 2 Hue -", "title": "Color 2 Hue Decrease", "shortName": "H2_DEC"},
+        {"name": "Color 2 Sat +", "title": "Color 2 Saturation Increase", "shortName": "S2_INC"},
+        {"name": "Color 2 Sat -", "title": "Color 2 Saturation Decrease", "shortName": "S2_DEC"},
+        {"name": "Globe", "title": "macOS Globe/Fn Key", "shortName": "GLOBE"}
+    ],
+    "layouts": {
+        "keymap": [
+            [
+                "0,0", "0,1", "0,2", "0,3", "0,4", "0,5", "0,6", "0,7", "0,8", "0,9", "0,10", "0,11", "0,12", {"w": 2}, "0,13", "0,14"
+            ],
+            [
+                {"w": 1.5}, "1,0", "1,1", "1,2", "1,3", "1,4", "1,5", "1,6", "1,7", "1,8", "1,9", "1,10", "1,11", "1,12", {"w": 1.5}, "2,12", "1,14"
+            ],
+            [
+                {"w": 1.75}, "2,0", "2,1", "2,2", "2,3", "2,4", "2,5", "2,6", "2,7", "2,8", "2,9", "2,10", "2,11", {"w": 2.25}, "2,13", "2,14"
+            ],
+            [
+                {"w": 2.25}, "3,0", "3,2", "3,3", "3,4", "3,5", "3,6", "3,7", "3,8", "3,9", "3,10", "3,11", {"w": 1.75}, "3,12", "3,13", "3,14"
+            ],
+            [
+                {"w": 1.25}, "4,0", {"w": 1.25}, "4,1", {"w": 1.25}, "4,2", {"w": 6.25}, "4,6", "4,9", "4,10", "4,11", "4,12", "4,13", "4,14"
+            ]
+        ]
+    }
+}

--- a/keyboards/novelkeys/nk65/readme.md
+++ b/keyboards/novelkeys/nk65/readme.md
@@ -3,11 +3,11 @@ NK65
 
 ![NK65](https://i.imgur.com/EXNbVpL.jpg)
 
-This is a standard fixed layout 65% PCB. It supports VIA and full per-key RGB.
+This is a standard fixed layout 65% PCB. It supports VIA, Vial, and full per-key RGB.
 
-Keyboard Maintainer: [Yiancar](http://yiancar-designs.com/) and on [GitHub](https://github.com/yiancar)   
-Hardware Supported: A 65% keyboard with STM32F303CC   
-Hardware Availability: https://novelkeys.xyz/   
+Keyboard Maintainer: [Yiancar](http://yiancar-designs.com/) and on [GitHub](https://github.com/yiancar)
+Hardware Supported: A 65% keyboard with STM32F303CC
+Hardware Availability: https://novelkeys.xyz/
 
 Due to the RGB implementation, the NK65 is currently not compatible with community layouts.
 
@@ -19,7 +19,15 @@ NOTE: For PCBs with revision v1.4 or later please use nk65/v1_4 in the make comm
 
 Make example for this keyboard (after setting up your build environment):
 
-    make novelkeys/nk65:via
+    make novelkeys/nk65:default
+
+For Vial support (real-time key remapping via https://vial.rocks):
+
+    make novelkeys/nk65:vial
+
+For Vial support with macOS Globe key functionality:
+
+    make novelkeys/nk65:vial_globe
 
 See the [build environment setup](https://docs.qmk.fm/#/getting_started_build_tools) and the [make instructions](https://docs.qmk.fm/#/getting_started_make_guide) for more information. Brand new to QMK? Start with our [Complete Newbs Guide](https://docs.qmk.fm/#/newbs).
 


### PR DESCRIPTION
Add Vial support for NK65 Entry Edition (base)

Changes
  - Added `vial` keymap to the base (v1.0-v1.3 revision) with Vial support and wilba_tech RGB controls
  - Added `vial_globe` keymap variant with Vial support, wilba_tech RGB controls and macOS Globe key support
  - Updated readme.md to document the new keymaps

Testing
  - Tested on NK65 Entry Edition v1.0-v1.3 hardware
  - Verified RGB controls work correctly
  - Verified Globe key functionality on macOS (vial_globe variant)
  - Confirmed Vial configurator detects and configures keyboard properly via https://vial.rocks