### PR TITLE
Vial rule lighting

### DIFF
--- a/builddefs/common_features.mk
+++ b/builddefs/common_features.mk
@@ -578,26 +578,19 @@ ifeq ($(strip $(RGB_MATRIX_ENABLE)), yes)
     ifeq ($(strip $(RGB_MATRIX_CUSTOM_USER)), yes)
         OPT_DEFS += -DRGB_MATRIX_CUSTOM_USER
     endif
-endif
 
-RULE_LIGHTING_ENABLE ?= no
+	RULE_LIGHTING_ENABLE ?= no
+	ifeq ($(strip $(RULE_LIGHTING_ENABLE)), yes)
+		OPT_DEFS += -DRULE_LIGHTING_ENABLE
+		SRC += $(QUANTUM_DIR)/rule_lighting.c
 
-ifeq ($(strip $(RULE_LIGHTING_ENABLE)), yes)
-    # Requires RGB Matrix
-    ifneq ($(strip $(RGB_MATRIX_ENABLE)), yes)
-        $(call CATASTROPHIC_ERROR,Invalid RULE_LIGHTING_ENABLE configuration,RULE_LIGHTING_ENABLE requires RGB_MATRIX_ENABLE)
-    endif
+		# Automatically enable required split state syncing for split keyboards
+		# These MUST be enabled for rule lighting to work on split keyboards
+		ifeq ($(strip $(SPLIT_KEYBOARD)), yes)
+			OPT_DEFS += -DSPLIT_LAYER_STATE_ENABLE -DSPLIT_LED_STATE_ENABLE -DSPLIT_MODS_ENABLE
+		endif
+	endif
 
-    OPT_DEFS += -DRULE_LIGHTING_ENABLE
-    SRC += $(QUANTUM_DIR)/rule_lighting.c
-
-    # Automatically enable required split state syncing for split keyboards
-    # These MUST be enabled for rule lighting to work on split keyboards
-    ifeq ($(strip $(SPLIT_KEYBOARD)), yes)
-        SPLIT_LAYER_STATE_ENABLE := yes
-        SPLIT_LED_STATE_ENABLE := yes
-        SPLIT_MODS_ENABLE := yes
-    endif
 endif
 
 VARIABLE_TRACE ?= no

--- a/builddefs/common_features.mk
+++ b/builddefs/common_features.mk
@@ -580,6 +580,26 @@ ifeq ($(strip $(RGB_MATRIX_ENABLE)), yes)
     endif
 endif
 
+RULE_LIGHTING_ENABLE ?= no
+
+ifeq ($(strip $(RULE_LIGHTING_ENABLE)), yes)
+    # Requires RGB Matrix
+    ifneq ($(strip $(RGB_MATRIX_ENABLE)), yes)
+        $(call CATASTROPHIC_ERROR,Invalid RULE_LIGHTING_ENABLE configuration,RULE_LIGHTING_ENABLE requires RGB_MATRIX_ENABLE)
+    endif
+
+    OPT_DEFS += -DRULE_LIGHTING_ENABLE
+    SRC += $(QUANTUM_DIR)/rule_lighting.c
+
+    # Automatically enable required split state syncing for split keyboards
+    # These MUST be enabled for rule lighting to work on split keyboards
+    ifeq ($(strip $(SPLIT_KEYBOARD)), yes)
+        SPLIT_LAYER_STATE_ENABLE := yes
+        SPLIT_LED_STATE_ENABLE := yes
+        SPLIT_MODS_ENABLE := yes
+    endif
+endif
+
 VARIABLE_TRACE ?= no
 ifneq ($(strip $(VARIABLE_TRACE)),no)
     SRC += $(QUANTUM_DIR)/variable_trace.c

--- a/builddefs/common_features.mk
+++ b/builddefs/common_features.mk
@@ -578,6 +578,19 @@ ifeq ($(strip $(RGB_MATRIX_ENABLE)), yes)
     ifeq ($(strip $(RGB_MATRIX_CUSTOM_USER)), yes)
         OPT_DEFS += -DRGB_MATRIX_CUSTOM_USER
     endif
+
+	RULE_LIGHTING_ENABLE ?= no
+	ifeq ($(strip $(RULE_LIGHTING_ENABLE)), yes)
+		OPT_DEFS += -DRULE_LIGHTING_ENABLE
+		SRC += $(QUANTUM_DIR)/rule_lighting.c
+
+		# Automatically enable required split state syncing for split keyboards
+		# These MUST be enabled for rule lighting to work on split keyboards
+		ifeq ($(strip $(SPLIT_KEYBOARD)), yes)
+			OPT_DEFS += -DSPLIT_LAYER_STATE_ENABLE -DSPLIT_LED_STATE_ENABLE -DSPLIT_MODS_ENABLE
+		endif
+	endif
+
 endif
 
 VARIABLE_TRACE ?= no

--- a/quantum/dynamic_keymap.c
+++ b/quantum/dynamic_keymap.c
@@ -49,8 +49,15 @@ uint16_t dynamic_keymap_get_keycode(uint8_t layer, uint8_t row, uint8_t column) 
     return nvm_dynamic_keymap_read_keycode(layer, row, column);
 }
 
+#ifdef SPLIT_KEYBOARD
+extern void dynamic_keymap_reset_sync(void);
+#endif
+
 void dynamic_keymap_set_keycode(uint8_t layer, uint8_t row, uint8_t column, uint16_t keycode) {
     nvm_dynamic_keymap_update_keycode(layer, row, column, keycode);
+#ifdef SPLIT_KEYBOARD
+    dynamic_keymap_reset_sync();
+#endif
 }
 
 #ifdef ENCODER_MAP_ENABLE

--- a/quantum/keyboard.c
+++ b/quantum/keyboard.c
@@ -61,7 +61,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #ifdef RGB_MATRIX_ENABLE
 #    include "rgb_matrix.h"
 #endif
-#if defined(RULE_LIGHTING_ENABLE) && defined(SPLIT_KEYBOARD)
+#ifdef RULE_LIGHTING_ENABLE
 #    include "rule_lighting.h"
 #endif
 #ifdef ENCODER_ENABLE

--- a/quantum/keyboard.c
+++ b/quantum/keyboard.c
@@ -61,6 +61,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #ifdef RGB_MATRIX_ENABLE
 #    include "rgb_matrix.h"
 #endif
+#if defined(RULE_LIGHTING_ENABLE) && defined(SPLIT_KEYBOARD)
+#    include "rule_lighting.h"
+#endif
 #ifdef ENCODER_ENABLE
 #    include "encoder.h"
 #endif
@@ -530,6 +533,9 @@ void keyboard_init(void) {
 #endif
 #ifdef SPLIT_KEYBOARD
     split_post_init();
+#endif
+#if defined(RULE_LIGHTING_ENABLE) && defined(SPLIT_KEYBOARD) && defined(DYNAMIC_KEYMAP_ENABLE)
+    rule_lighting_post_init();
 #endif
 #ifdef POINTING_DEVICE_ENABLE
     // init after split init

--- a/quantum/keyboard.c
+++ b/quantum/keyboard.c
@@ -60,6 +60,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #endif
 #ifdef RGB_MATRIX_ENABLE
 #    include "rgb_matrix.h"
+#  if defined(RULE_LIGHTING_ENABLE)
+#    include "rule_lighting.h"
+#  endif
 #endif
 #ifdef ENCODER_ENABLE
 #    include "encoder.h"
@@ -542,6 +545,9 @@ void keyboard_init(void) {
 #endif
 #ifdef SPLIT_KEYBOARD
     split_post_init();
+#endif
+#if defined(RULE_LIGHTING_ENABLE) && defined(SPLIT_KEYBOARD) && defined(DYNAMIC_KEYMAP_ENABLE)
+    rule_lighting_post_init();
 #endif
 #ifdef POINTING_DEVICE_ENABLE
     // init after split init

--- a/quantum/nvm/eeprom/nvm_dynamic_keymap.c
+++ b/quantum/nvm/eeprom/nvm_dynamic_keymap.c
@@ -41,16 +41,14 @@ STATIC_ASSERT(DYNAMIC_KEYMAP_EEPROM_MAX_ADDR <= 65535, "DYNAMIC_KEYMAP_EEPROM_MA
 #    define DYNAMIC_KEYMAP_ENCODER_EEPROM_ADDR (DYNAMIC_KEYMAP_EEPROM_ADDR + (DYNAMIC_KEYMAP_LAYER_COUNT * MATRIX_ROWS * MATRIX_COLS * 2))
 #endif
 
-// Dynamic macro starts after dynamic encoders, but only when using ENCODER_MAP
-#ifdef ENCODER_MAP_ENABLE
-#    ifndef DYNAMIC_KEYMAP_MACRO_EEPROM_ADDR
+// Dynamic macro starts after dynamic encoders
+#ifndef DYNAMIC_KEYMAP_MACRO_EEPROM_ADDR
+#    ifdef ENCODER_MAP_ENABLE
 #        define DYNAMIC_KEYMAP_MACRO_EEPROM_ADDR (DYNAMIC_KEYMAP_ENCODER_EEPROM_ADDR + (DYNAMIC_KEYMAP_LAYER_COUNT * NUM_ENCODERS * 2 * 2))
-#    endif // DYNAMIC_KEYMAP_MACRO_EEPROM_ADDR
-#else      // ENCODER_MAP_ENABLE
-#    ifndef DYNAMIC_KEYMAP_MACRO_EEPROM_ADDR
+#    else
 #        define DYNAMIC_KEYMAP_MACRO_EEPROM_ADDR (DYNAMIC_KEYMAP_ENCODER_EEPROM_ADDR)
-#    endif // DYNAMIC_KEYMAP_MACRO_EEPROM_ADDR
-#endif     // ENCODER_MAP_ENABLE
+#    endif
+#endif
 
 // Sanity check that dynamic keymaps fit in available EEPROM
 // If there's not 100 bytes available for macros, then something is wrong.

--- a/quantum/nvm/eeprom/nvm_dynamic_keymap.c
+++ b/quantum/nvm/eeprom/nvm_dynamic_keymap.c
@@ -90,9 +90,19 @@ STATIC_ASSERT(DYNAMIC_KEYMAP_EEPROM_MAX_ADDR <= 65535, "DYNAMIC_KEYMAP_EEPROM_MA
 #define VIAL_ALT_REPEAT_KEY_SIZE 0
 #endif
 
+// RGB Indicator
+#define RULE_LIGHTING_EEPROM_ADDR (VIAL_ALT_REPEAT_KEY_EEPROM_ADDR + VIAL_ALT_REPEAT_KEY_SIZE)
+
+#ifdef RULE_LIGHTING_ENABLE
+#include "rule_lighting.h"
+#define RULE_LIGHTING_SIZE (sizeof(rule_lighting_entry_t) * RULE_LIGHTING_ENTRIES)
+#else
+#define RULE_LIGHTING_SIZE 0
+#endif
+
 // Dynamic macro
 #ifndef DYNAMIC_KEYMAP_MACRO_EEPROM_ADDR
-#    define DYNAMIC_KEYMAP_MACRO_EEPROM_ADDR (VIAL_ALT_REPEAT_KEY_EEPROM_ADDR + VIAL_ALT_REPEAT_KEY_SIZE)
+#    define DYNAMIC_KEYMAP_MACRO_EEPROM_ADDR (RULE_LIGHTING_EEPROM_ADDR + RULE_LIGHTING_SIZE)
 #endif
 
 // Sanity check that dynamic keymaps fit in available EEPROM
@@ -384,5 +394,17 @@ int nvm_dynamic_keymap_set_alt_repeat_key(uint8_t index, const vial_alt_repeat_k
     eeprom_write_block(entry, address, sizeof(vial_alt_repeat_key_entry_t));
 
     return 0;
+}
+#endif
+
+#ifdef RULE_LIGHTING_ENABLE
+void nvm_dynamic_keymap_load_rgb_indicators(rule_lighting_entry_t *entries) {
+    void *address = (void*)RULE_LIGHTING_EEPROM_ADDR;
+    eeprom_read_block(entries, address, sizeof(rule_lighting_entry_t) * RULE_LIGHTING_ENTRIES);
+}
+
+void nvm_dynamic_keymap_save_rgb_indicators(const rule_lighting_entry_t *entries) {
+    void *address = (void*)RULE_LIGHTING_EEPROM_ADDR;
+    eeprom_write_block(entries, address, sizeof(rule_lighting_entry_t) * RULE_LIGHTING_ENTRIES);
 }
 #endif

--- a/quantum/rgb_matrix/animations/rgb_matrix_effects.inc
+++ b/quantum/rgb_matrix/animations/rgb_matrix_effects.inc
@@ -44,3 +44,4 @@
 #include "starlight_dual_sat_anim.h"
 #include "starlight_dual_hue_anim.h"
 #include "riverflow_anim.h"
+#include "rule_lighting_anim.h"

--- a/quantum/rgb_matrix/animations/rgb_matrix_effects.inc
+++ b/quantum/rgb_matrix/animations/rgb_matrix_effects.inc
@@ -45,3 +45,4 @@
 #include "starlight_dual_hue_anim.h"
 #include "riverflow_anim.h"
 #include "vialrgb_direct_anim.h"
+#include "rule_lighting_anim.h"

--- a/quantum/rgb_matrix/animations/rule_lighting_anim.h
+++ b/quantum/rgb_matrix/animations/rule_lighting_anim.h
@@ -33,18 +33,13 @@ static int8_t rule_lighting_find_match(uint16_t keycode, uint8_t current_layer, 
     for (uint8_t i = 0; i < RULE_LIGHTING_ENTRIES; i++) {
         const rule_lighting_entry_t *rule = &rules[i];
 
-        /* Skip empty entries */
-        if (!RGB_MATRIX_SAT_IS_ON(rule->sat_idle) && !RGB_MATRIX_SAT_IS_ON(rule->sat_pressed)) {
-            continue;
-        }
-
         /* Layer check */
         if (rule->layer_enable && current_layer != rule->layer) {
             continue;
         }
 
-        /* Mods check (OR logic) */
-        if (rule->mods != 0 && (current_mods & rule->mods) == 0) {
+        /* Mods check, if any mod in rule, exact match */
+        if (rule->mods != 0 && rule->mods != current_mods) {
             continue;
         }
 

--- a/quantum/rgb_matrix/animations/rule_lighting_anim.h
+++ b/quantum/rgb_matrix/animations/rule_lighting_anim.h
@@ -1,0 +1,182 @@
+/* Copyright 2026 Javier Domingo
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifdef RULE_LIGHTING_ENABLE
+#    define RGB_MATRIX_EFFECT_RULE_LIGHTING
+RGB_MATRIX_EFFECT(RULE_LIGHTING)
+#    ifdef RGB_MATRIX_CUSTOM_EFFECT_IMPLS
+
+#        include "rule_lighting.h"
+#        include "action_layer.h"
+#        include "action_util.h"
+#        include "host.h"
+
+/**
+ * Find a matching rule for a key (first-match-wins)
+ */
+static int8_t rule_lighting_find_match(uint16_t keycode, uint8_t current_layer, uint8_t current_mods, bool caps_on) {
+    const rule_lighting_entry_t *rules = rule_lighting_get_rules();
+
+    for (uint8_t i = 0; i < RULE_LIGHTING_ENTRIES; i++) {
+        const rule_lighting_entry_t *rule = &rules[i];
+
+        /* Skip empty entries */
+        if (!RGB_MATRIX_SAT_IS_ON(rule->sat_idle) && !RGB_MATRIX_SAT_IS_ON(rule->sat_pressed)) {
+            continue;
+        }
+
+        /* Layer check */
+        if (rule->layer_enable && current_layer != rule->layer) {
+            continue;
+        }
+
+        /* Mods check (OR logic) */
+        if (rule->mods != 0 && (current_mods & rule->mods) == 0) {
+            continue;
+        }
+
+        /* Caps check */
+        if (rule->caps_enable && !caps_on) {
+            continue;
+        }
+
+        /* Keycode range check */
+        if (keycode >= rule->keycode_start && keycode <= rule->keycode_end) {
+            return i;
+        }
+    }
+    return -1;
+}
+
+/**
+ * Get the tick (time since last press) for an LED
+ */
+static uint16_t rule_lighting_get_tick(uint8_t led_index, uint8_t speed) {
+#        ifdef RGB_MATRIX_KEYREACTIVE_ENABLED
+    uint16_t max_tick = 65535 / qadd8(speed, 1);
+
+    for (int8_t j = g_last_hit_tracker.count - 1; j >= 0; j--) {
+        if (g_last_hit_tracker.index[j] == led_index) {
+            return g_last_hit_tracker.tick[j];
+        }
+    }
+    return max_tick;
+#        else
+    return 65535;
+#        endif
+}
+
+/**
+ * Calculate color for a key based on its rule and press state
+ */
+static void rule_lighting_calc_color(const rule_lighting_entry_t *rule, uint16_t tick, uint8_t speed, uint8_t *h, uint8_t *s, uint8_t *v) {
+    uint16_t scaled_time = scale16by8(tick, qadd8(speed, 1));
+    uint8_t  blend       = (scaled_time > 255) ? 255 : (uint8_t)scaled_time;
+
+    uint8_t brightness = rgb_matrix_get_val();
+
+    uint8_t h_idle    = RGB_MATRIX_HUE_6TO8(rule->h_idle);
+    uint8_t h_pressed = RGB_MATRIX_HUE_6TO8(rule->h_pressed);
+    uint8_t s_idle    = rgb_matrix_sat_to_value(rule->sat_idle);
+    uint8_t s_pressed = rgb_matrix_sat_to_value(rule->sat_pressed);
+
+    bool pressed_off = !RGB_MATRIX_SAT_IS_ON(rule->sat_pressed);
+    bool idle_off    = !RGB_MATRIX_SAT_IS_ON(rule->sat_idle);
+
+    if (blend < 255) {
+        if (pressed_off) {
+            *h = h_idle;
+            *s = s_idle;
+            *v = scale8(brightness, blend);
+        } else if (idle_off) {
+            *h = h_pressed;
+            *s = s_pressed;
+            *v = scale8(brightness, 255 - blend);
+        } else {
+            *h = lerp8by8(h_pressed, h_idle, blend);
+            *s = lerp8by8(s_pressed, s_idle, blend);
+            *v = brightness;
+        }
+    } else {
+        if (idle_off) {
+            *h = 0;
+            *s = 0;
+            *v = 0;
+        } else {
+            *h = h_idle;
+            *s = s_idle;
+            *v = brightness;
+        }
+    }
+}
+
+bool RULE_LIGHTING(effect_params_t *params) {
+    RGB_MATRIX_USE_LIMITS(led_min, led_max);
+
+    /* Get current keyboard state */
+    uint8_t current_layer = get_highest_layer(layer_state);
+    uint8_t current_mods  = get_mods() | get_weak_mods();
+#        ifndef NO_ACTION_ONESHOT
+    current_mods |= get_oneshot_mods();
+#        endif
+    bool caps_on = host_keyboard_led_state().caps_lock;
+
+    /* Iterate over the key matrix, but only process LEDs in our range */
+    for (uint8_t row = 0; row < MATRIX_ROWS; row++) {
+        for (uint8_t col = 0; col < MATRIX_COLS; col++) {
+            uint8_t led_index = g_led_config.matrix_co[row][col];
+
+            /* Skip if no LED or outside our processing range */
+            if (led_index == NO_LED || led_index < led_min || led_index >= led_max) {
+                continue;
+            }
+
+            /* Check LED flags */
+            if (!HAS_ANY_FLAGS(g_led_config.flags[led_index], params->flags)) {
+                continue;
+            }
+
+            /* Get the keycode for this key on the current layer
+             * Uses synced keymap for split keyboard support */
+            uint16_t keycode = get_synced_keycode(current_layer, row, col);
+
+            /* Find matching rule */
+            int8_t rule_idx = rule_lighting_find_match(keycode, current_layer, current_mods, caps_on);
+
+            if (rule_idx >= 0) {
+                const rule_lighting_entry_t *rules = rule_lighting_get_rules();
+                const rule_lighting_entry_t *rule  = &rules[rule_idx];
+                uint8_t                      speed = rgb_matrix_get_speed();
+                uint16_t                     tick  = rule_lighting_get_tick(led_index, speed);
+
+                uint8_t h, s, v;
+                rule_lighting_calc_color(rule, tick, speed, &h, &s, &v);
+
+                hsv_t hsv = {.h = h, .s = s, .v = v};
+                rgb_t rgb = rgb_matrix_hsv_to_rgb(hsv);
+                rgb_matrix_set_color(led_index, rgb.r, rgb.g, rgb.b);
+            } else {
+                /* No matching rule - set to black */
+                rgb_matrix_set_color(led_index, 0, 0, 0);
+            }
+        }
+    }
+
+    return rgb_matrix_check_finished_leds(led_max);
+}
+
+#    endif /* RGB_MATRIX_CUSTOM_EFFECT_IMPLS */
+#endif     /* RULE_LIGHTING_ENABLE */

--- a/quantum/rgb_matrix/animations/rule_lighting_anim.h
+++ b/quantum/rgb_matrix/animations/rule_lighting_anim.h
@@ -1,0 +1,179 @@
+/* Copyright 2026 Javier Domingo
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifdef RULE_LIGHTING_ENABLE
+#    define RGB_MATRIX_EFFECT_RULE_LIGHTING
+RGB_MATRIX_EFFECT(RULE_LIGHTING)
+#    ifdef RGB_MATRIX_CUSTOM_EFFECT_IMPLS
+
+#        include "rule_lighting.h"
+#        include "action_layer.h"
+#        include "action_util.h"
+#        include "host.h"
+
+/**
+ * Find a matching rule for a key (first-match-wins)
+ */
+static int8_t rule_lighting_find_match(uint16_t keycode, uint8_t current_layer, uint8_t current_mods, bool caps_on) {
+    const rule_lighting_entry_t *rules = rule_lighting_get_rules();
+
+    for (uint8_t i = 0; i < RULE_LIGHTING_ENTRIES; i++) {
+        const rule_lighting_entry_t *rule = &rules[i];
+
+        /* Layer check */
+        if (rule->layer_enable && current_layer != rule->layer) {
+            continue;
+        }
+
+        /* Mods check, if any mod in rule, exact match */
+        if (rule->mods != 0 && rule->mods != current_mods) {
+            continue;
+        }
+
+        /* Caps check */
+        if (rule->caps_enable && !caps_on) {
+            continue;
+        }
+
+        /* Keycode range check */
+        if (keycode >= rule->keycode_start && keycode <= rule->keycode_end) {
+            return i;
+        }
+    }
+    return -1;
+}
+
+/**
+ * Get the tick (time since last press) for an LED
+ */
+static uint16_t rule_lighting_get_tick(uint8_t led_index, uint8_t speed) {
+#        ifdef RGB_MATRIX_KEYREACTIVE_ENABLED
+    uint16_t max_tick = 65535 / qadd8(speed, 1);
+
+    for (int8_t j = g_last_hit_tracker.count - 1; j >= 0; j--) {
+        if (g_last_hit_tracker.index[j] == led_index) {
+            return g_last_hit_tracker.tick[j];
+        }
+    }
+    return max_tick;
+#        else
+    return 65535;
+#        endif
+}
+
+/**
+ * Calculate color for a key based on its rule and press state
+ */
+static void rule_lighting_calc_color(const rule_lighting_entry_t *rule, uint16_t tick, uint8_t speed, uint8_t *h, uint8_t *s, uint8_t *v) {
+    uint16_t scaled_time = scale16by8(tick, qadd8(speed, 1));
+    uint8_t  blend       = (scaled_time > 255) ? 255 : (uint8_t)scaled_time;
+
+    uint8_t brightness = rgb_matrix_get_val();
+
+    uint8_t h_idle    = RGB_MATRIX_HUE_6TO8(rule->h_idle);
+    uint8_t h_pressed = RGB_MATRIX_HUE_6TO8(rule->h_pressed);
+    uint8_t s_idle    = rgb_matrix_sat_to_value(rule->sat_idle);
+    uint8_t s_pressed = rgb_matrix_sat_to_value(rule->sat_pressed);
+
+    bool pressed_off = !RGB_MATRIX_SAT_IS_ON(rule->sat_pressed);
+    bool idle_off    = !RGB_MATRIX_SAT_IS_ON(rule->sat_idle);
+
+    if (blend < 255) {
+        if (pressed_off) {
+            *h = h_idle;
+            *s = s_idle;
+            *v = scale8(brightness, blend);
+        } else if (idle_off) {
+            *h = h_pressed;
+            *s = s_pressed;
+            *v = scale8(brightness, 255 - blend);
+        } else {
+            *h = lerp8by8(h_pressed, h_idle, blend);
+            *s = lerp8by8(s_pressed, s_idle, blend);
+            *v = brightness;
+        }
+    } else {
+        if (idle_off) {
+            *h = 0;
+            *s = 0;
+            *v = 0;
+        } else {
+            *h = h_idle;
+            *s = s_idle;
+            *v = brightness;
+        }
+    }
+}
+
+bool RULE_LIGHTING(effect_params_t *params) {
+    RGB_MATRIX_USE_LIMITS(led_min, led_max);
+
+    /* Get current keyboard state */
+    uint8_t current_layer = get_highest_layer(layer_state);
+    uint8_t current_mods  = get_mods() | get_weak_mods();
+#        ifndef NO_ACTION_ONESHOT
+    current_mods |= get_oneshot_mods();
+#        endif
+    bool caps_on = host_keyboard_led_state().caps_lock;
+
+    /* Get rules array */
+    const rule_lighting_entry_t *entries = rule_lighting_get_rules();
+
+    /* Iterate over the key matrix, but only process LEDs in our range */
+    for (uint8_t row = 0; row < MATRIX_ROWS; row++) {
+        for (uint8_t col = 0; col < MATRIX_COLS; col++) {
+            uint8_t led_index = g_led_config.matrix_co[row][col];
+
+            /* Skip if no LED or outside our processing range */
+            if (led_index == NO_LED || led_index < led_min || led_index >= led_max) {
+                continue;
+            }
+
+            /* Check LED flags */
+            if (!HAS_ANY_FLAGS(g_led_config.flags[led_index], params->flags)) {
+                continue;
+            }
+
+            /* Get the keycode for this key on the current layer
+             * Uses synced keymap for split keyboard support */
+            uint16_t keycode = get_synced_keycode(current_layer, row, col);
+
+            /* Find matching rule */
+            int8_t rule_idx = rule_lighting_find_match(keycode, current_layer, current_mods, caps_on);
+
+            if (rule_idx >= 0) {
+                const rule_lighting_entry_t *rule = &entries[rule_idx];
+                uint8_t speed = rgb_matrix_get_speed();
+                uint16_t tick = rule_lighting_get_tick(led_index, speed);
+
+                uint8_t h, s, v;
+                rule_lighting_calc_color(rule, tick, speed, &h, &s, &v);
+
+                hsv_t hsv = {.h = h, .s = s, .v = v};
+                rgb_t rgb = rgb_matrix_hsv_to_rgb(hsv);
+                rgb_matrix_set_color(led_index, rgb.r, rgb.g, rgb.b);
+            } else {
+                /* No matching rule - set to black */
+                rgb_matrix_set_color(led_index, 0, 0, 0);
+            }
+        }
+    }
+
+    return rgb_matrix_check_finished_leds(led_max);
+}
+
+#    endif /* RGB_MATRIX_CUSTOM_EFFECT_IMPLS */
+#endif     /* RULE_LIGHTING_ENABLE */

--- a/quantum/rgb_matrix/rgb_matrix.c
+++ b/quantum/rgb_matrix/rgb_matrix.c
@@ -22,11 +22,16 @@
 #include "keyboard.h"
 #include "sync_timer.h"
 #include "debug.h"
+#include "print.h"
 #include <string.h>
 #include <math.h>
 #include <stdlib.h>
 
 #include <lib/lib8tion/lib8tion.h>
+
+#ifdef RULE_LIGHTING_ENABLE
+#    include "rule_lighting.h"
+#endif
 
 #ifndef RGB_MATRIX_CENTER
 const led_point_t k_rgb_matrix_center = {112, 32};
@@ -395,6 +400,10 @@ static void rgb_task_flush(uint8_t effect) {
 void rgb_matrix_task(void) {
     rgb_task_timers();
 
+#ifdef RULE_LIGHTING_ENABLE
+    rule_lighting_task();
+#endif
+
     uint8_t effect = rgb_current_effect;
 
     switch (rgb_task_state) {
@@ -507,6 +516,10 @@ void rgb_matrix_init(void) {
         dprintf("rgb_matrix_init_drivers rgb_matrix_config.mode = 0. Write default values to EEPROM.\n");
         eeconfig_update_rgb_matrix_default();
     }
+#ifdef RULE_LIGHTING_ENABLE
+    // Initialize rule_lighting - registers split RPC handlers for flash-based rules
+    rule_lighting_init();
+#endif
     eeconfig_debug_rgb_matrix(); // display current eeprom values
 }
 

--- a/quantum/rgb_matrix/rgb_matrix.c
+++ b/quantum/rgb_matrix/rgb_matrix.c
@@ -22,11 +22,16 @@
 #include "keyboard.h"
 #include "sync_timer.h"
 #include "debug.h"
+#include "print.h"
 #include <string.h>
 #include <math.h>
 #include <stdlib.h>
 
 #include <lib/lib8tion/lib8tion.h>
+
+#ifdef RULE_LIGHTING_ENABLE
+#    include "rule_lighting.h"
+#endif
 
 #ifndef RGB_MATRIX_CENTER
 const led_point_t k_rgb_matrix_center = {112, 32};
@@ -100,6 +105,9 @@ const uint8_t k_rgb_matrix_split[2] = RGB_MATRIX_SPLIT;
 EECONFIG_DEBOUNCE_HELPER(rgb_matrix, rgb_matrix_config);
 
 void eeconfig_force_flush_rgb_matrix(void) {
+#ifdef RULE_LIGHTING_ENABLE
+    rule_lighting_save();
+#endif
     eeconfig_flush_rgb_matrix(true);
 }
 
@@ -110,6 +118,9 @@ void eeconfig_update_rgb_matrix_default(void) {
     rgb_matrix_config.hsv    = (hsv_t){RGB_MATRIX_DEFAULT_HUE, RGB_MATRIX_DEFAULT_SAT, RGB_MATRIX_DEFAULT_VAL};
     rgb_matrix_config.speed  = RGB_MATRIX_DEFAULT_SPD;
     rgb_matrix_config.flags  = RGB_MATRIX_DEFAULT_FLAGS;
+#ifdef RULE_LIGHTING_ENABLE
+    rule_lighting_reset();
+#endif
     eeconfig_flush_rgb_matrix(true);
 }
 
@@ -395,6 +406,10 @@ static void rgb_task_flush(uint8_t effect) {
 void rgb_matrix_task(void) {
     rgb_task_timers();
 
+#ifdef RULE_LIGHTING_ENABLE
+    rule_lighting_task();
+#endif
+
     uint8_t effect = rgb_current_effect;
 
     switch (rgb_task_state) {
@@ -507,6 +522,11 @@ void rgb_matrix_init(void) {
         dprintf("rgb_matrix_init_drivers rgb_matrix_config.mode = 0. Write default values to EEPROM.\n");
         eeconfig_update_rgb_matrix_default();
     }
+#ifdef RULE_LIGHTING_ENABLE
+    // Initialize rule_lighting - registers split RPC handlers
+    // (rule_lighting_reset was called above if mode==0, but init still needed for sync)
+    rule_lighting_init();
+#endif
     eeconfig_debug_rgb_matrix(); // display current eeprom values
 }
 

--- a/quantum/rgb_matrix/rgb_matrix.h
+++ b/quantum/rgb_matrix/rgb_matrix.h
@@ -25,6 +25,10 @@
 #include "color.h"
 #include "keyboard.h"
 
+#ifdef RULE_LIGHTING_ENABLE
+#include "rule_lighting.h"
+#endif
+
 #ifndef RGB_MATRIX_TIMEOUT
 #    define RGB_MATRIX_TIMEOUT 0
 #endif

--- a/quantum/rule_lighting.c
+++ b/quantum/rule_lighting.c
@@ -1,0 +1,157 @@
+/* Copyright 2026 Javier Domingo
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "rule_lighting.h"
+#include "keymap_introspection.h"
+#include <string.h>
+
+#ifdef SPLIT_KEYBOARD
+#    include "keyboard.h"
+#    include "transactions.h"
+#    include "timer.h"
+#    include "split_util.h"
+#endif
+
+#ifdef RGB_MATRIX_ENABLE
+
+/**
+ * Rules array defined by user in keymap.c
+ * Weak default provides empty array if not defined
+ */
+__attribute__((weak)) const rule_lighting_entry_t rules[RULE_LIGHTING_ENTRIES] = {0};
+
+#    if defined(SPLIT_KEYBOARD) && defined(DYNAMIC_KEYMAP_ENABLE)
+/* Slave-side RAM copy of rules synced from master
+ * Sync is needed with DYNAMIC_KEYMAP because:
+ * - EEPROM is per-chip (independent on each half)
+ * - Keymaps can diverge between halves via VIA/HID writes
+ * For static keymaps, both halves read rules directly from flash (no sync needed)
+ */
+static rule_lighting_entry_t slave_rules[RULE_LIGHTING_ENTRIES];
+
+/* Master-side sync state */
+static bool master_sync_complete = false;
+#    endif
+
+/**
+ * Get rules array (master uses flash, slave uses RAM copy only for dynamic keymaps)
+ */
+const rule_lighting_entry_t *rule_lighting_get_rules(void) {
+#    if defined(SPLIT_KEYBOARD) && defined(DYNAMIC_KEYMAP_ENABLE)
+    if (!is_keyboard_master()) {
+        return slave_rules;
+    }
+#    endif
+    return rules;
+}
+
+/**
+ * Get keycode for a key position (supports split keyboard)
+ * Uses keymap introspection on master, returns KC_NO on slave
+ */
+uint16_t get_synced_keycode(uint8_t layer, uint8_t row, uint8_t col) {
+    /* Use keymap introspection to get keycode from EEPROM/flash */
+    if (layer >= keymap_layer_count() || row >= MATRIX_ROWS || col >= MATRIX_COLS) {
+        return KC_NO;
+    }
+
+    /* Both master and slave use keycode_at_keymap_location()
+     * This reads from EEPROM if DYNAMIC_KEYMAP is enabled, flash otherwise */
+    return keycode_at_keymap_location(layer, row, col);
+}
+
+#    if defined(SPLIT_KEYBOARD) && defined(DYNAMIC_KEYMAP_ENABLE)
+
+/**
+ * Slave handler for rule sync RPC
+ * Receives rules from master and sends ACK back
+ */
+static void rule_lighting_slave_handler(uint8_t m2s_size, const void *m2s_buffer, uint8_t s2m_size, void *s2m_buffer) {
+    uint8_t *ack = (uint8_t *)s2m_buffer;
+
+    if (m2s_size == sizeof(slave_rules) && s2m_size >= 1) {
+        memcpy(slave_rules, m2s_buffer, sizeof(slave_rules));
+        *ack = 1; /* Send ACK */
+    } else if (s2m_size >= 1) {
+        *ack = 0; /* Invalid size */
+    }
+}
+
+/**
+ * Master sync - sync rules to slave on connection
+ * Handles late slave connection by detecting disconnection and resetting sync state
+ */
+static void rule_lighting_master_sync(void) {
+    /* If sync complete, check if slave disconnected to reset state */
+    if (master_sync_complete) {
+        if (!is_transport_connected()) {
+            master_sync_complete = false;
+        }
+        return;
+    }
+
+    /* Try syncing if not complete and slave is connected */
+    if (is_transport_connected()) {
+        static uint32_t last_attempt = 0;
+        if (timer_elapsed32(last_attempt) > 500) {
+            last_attempt = timer_read32();
+
+            /* Send rules and check ACK */
+            uint8_t ack = 0;
+            if (transaction_rpc_exec(SPLIT_RULE_LIGHTING_SYNC_ID, sizeof(rules), rules, sizeof(ack), &ack)) {
+                if (ack == 1) {
+                    master_sync_complete = true;
+                }
+            }
+        }
+    }
+}
+
+/**
+ * Register split transactions - must be called AFTER split_post_init()
+ */
+void rule_lighting_post_init(void) {
+    transaction_register_rpc(SPLIT_RULE_LIGHTING_SYNC_ID, rule_lighting_slave_handler);
+}
+
+#    endif /* SPLIT_KEYBOARD && DYNAMIC_KEYMAP_ENABLE */
+
+/**
+ * Housekeeping task for rule lighting
+ * Handles split sync on master when dynamic keymaps are enabled
+ */
+void rule_lighting_task(void) {
+#    if defined(SPLIT_KEYBOARD) && defined(DYNAMIC_KEYMAP_ENABLE)
+    if (is_keyboard_master()) {
+        rule_lighting_master_sync();
+    }
+#    endif
+}
+
+/**
+ * Initialize rule lighting (called from rgb_matrix_init)
+ * No-op for flash-only implementation
+ */
+void rule_lighting_init(void) {
+#    if defined(SPLIT_KEYBOARD) && defined(DYNAMIC_KEYMAP_ENABLE)
+    /* Clear slave rules on init */
+    if (!is_keyboard_master()) {
+        memset(slave_rules, 0, sizeof(slave_rules));
+    }
+#    endif
+}
+
+#endif /* RGB_MATRIX_ENABLE */

--- a/quantum/rule_lighting.c
+++ b/quantum/rule_lighting.c
@@ -14,6 +14,8 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#ifdef RGB_MATRIX_ENABLE
+
 #include "rule_lighting.h"
 #include "keymap_introspection.h"
 #include <string.h>
@@ -24,8 +26,6 @@
 #    include "timer.h"
 #    include "split_util.h"
 #endif
-
-#ifdef RGB_MATRIX_ENABLE
 
 /**
  * Rules array defined by user in keymap.c

--- a/quantum/rule_lighting.c
+++ b/quantum/rule_lighting.c
@@ -1,0 +1,233 @@
+/* Copyright 2026 Javier Domingo
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifdef RGB_MATRIX_ENABLE
+
+#include "rule_lighting.h"
+#include "keymap_introspection.h"
+#include "dynamic_keymap.h"
+#include <string.h>
+
+#ifdef SPLIT_KEYBOARD
+#    include "keyboard.h"
+#    include "transactions.h"
+#    include "timer.h"
+#    include "split_util.h"
+#endif
+
+/* Forward declarations for EEPROM access */
+extern void nvm_dynamic_keymap_load_rgb_indicators(rule_lighting_entry_t *entries);
+extern void nvm_dynamic_keymap_save_rgb_indicators(const rule_lighting_entry_t *entries);
+
+/**
+ * Rules array defined by user in keymap.c
+ * Weak default provides empty array if not defined
+ */
+__attribute__((weak)) const rule_lighting_entry_t rules[RULE_LIGHTING_ENTRIES] = {0};
+
+#    if defined(SPLIT_KEYBOARD) && defined(DYNAMIC_KEYMAP_ENABLE)
+/* Slave-side RAM copy of rules synced from master
+ * Sync is needed with DYNAMIC_KEYMAP because:
+ * - EEPROM is per-chip (independent on each half)
+ * - Keymaps can diverge between halves via VIA/HID writes
+ * For static keymaps, both halves read rules directly from flash (no sync needed)
+ */
+static rule_lighting_entry_t slave_rules[RULE_LIGHTING_ENTRIES];
+
+/* Reset rule lighting to defaults from flash and save to EEPROM */
+void rule_lighting_reset(void) {
+    for (uint8_t i = 0; i < RULE_LIGHTING_ENTRIES; i++) {
+        slave_rules[i] = rules[i];
+    }
+    nvm_dynamic_keymap_save_rgb_indicators(slave_rules);
+}
+
+/* Master-side sync state */
+static bool master_sync_complete = false;
+#    endif
+
+/**
+ * Get rules array (master uses flash, slave uses RAM copy only for dynamic keymaps)
+ */
+const rule_lighting_entry_t *rule_lighting_get_rules(void) {
+    return slave_rules;
+}
+
+/**
+ * Save all rule lighting data to EEPROM
+ */
+void rule_lighting_save(void) {
+    nvm_dynamic_keymap_save_rgb_indicators(slave_rules);
+}
+
+static uint16_t synced_keymap[DYNAMIC_KEYMAP_LAYER_COUNT][MATRIX_ROWS][MATRIX_COLS];
+
+/**
+ * Get keycode for a key position (supports split keyboard)
+ * Resolves KC_TRNS by walking down layers to find actual keycode
+ */
+uint16_t get_synced_keycode(uint8_t layer, uint8_t row, uint8_t col) {
+    /* Use keymap introspection to get keycode from RAM/EEPROM/flash */
+    if (layer >= keymap_layer_count() || row >= MATRIX_ROWS || col >= MATRIX_COLS) {
+        return KC_NO;
+    }
+
+    bool use_synced = !is_keyboard_master();
+    for (int8_t l = layer; l >= 0; l--) {
+
+#    if defined(SPLIT_KEYBOARD) && defined(DYNAMIC_KEYMAP_ENABLE)
+        uint16_t kc = use_synced ? synced_keymap[l][row][col]
+                                 : dynamic_keymap_get_keycode(l, row, col);
+#    else
+        uint16_t kc = keycode_at_keymap_location_raw(l, row, col);
+#    endif
+        if (kc != KC_TRNS) {
+            return kc;
+        }
+    }
+    return KC_NO;
+}
+
+#    if defined(SPLIT_KEYBOARD) && defined(DYNAMIC_KEYMAP_ENABLE)
+
+/**
+ * Slave handler for rule sync RPC
+ * Receives rules from master and sends ACK back
+ */
+static void rule_lighting_slave_handler(uint8_t m2s_size, const void *m2s_buffer, uint8_t s2m_size, void *s2m_buffer) {
+    uint8_t *ack = (uint8_t *)s2m_buffer;
+
+    if (m2s_size == sizeof(slave_rules) && s2m_size >= 1) {
+        memcpy(slave_rules, m2s_buffer, sizeof(slave_rules));
+        *ack = 1; /* Send ACK */
+    } else if (s2m_size >= 1) {
+        *ack = 0; /* Invalid size */
+    }
+}
+
+/**
+ * Slave callback for keymap sync
+ */
+static void keymap_slave_handler(uint8_t m2s_size, const void *m2s_buffer, uint8_t s2m_size, void *s2m_buffer) {
+    uint8_t *ack = (uint8_t *)s2m_buffer;
+
+    if (m2s_size == sizeof(keymap_layer_sync_t) && s2m_size >= 1) {
+        const keymap_layer_sync_t *data = (const keymap_layer_sync_t *)m2s_buffer;
+
+        if (data->layer >= DYNAMIC_KEYMAP_LAYER_COUNT) {
+            *ack = 0;
+            return;
+        }
+
+        memcpy(synced_keymap[data->layer], data->keycodes, sizeof(data->keycodes));
+        *ack = 1; /* Send ACK */
+    } else if (s2m_size >= 1) {
+        *ack = 0; /* Invalid size */
+    }
+}
+
+/**
+ * Reset keymap sync - called when dynamic keymap is modified
+ */
+void dynamic_keymap_reset_sync(void) {
+    master_sync_complete = false;
+}
+
+/**
+ * Master sync - sync rules to slave on connection
+ * Handles late slave connection by detecting disconnection and resetting sync state
+ */
+static void rule_lighting_master_sync(void) {
+    /* If not connected and sync was complete, reset sync state */
+    if (!is_transport_connected()) {
+        if (master_sync_complete) {
+            master_sync_complete = false;
+        }
+        return;
+    }
+
+    /* If sync complete, nothing to do */
+    if (master_sync_complete) {
+        return;
+    }
+
+    /* Rate limit to once per 500ms */
+    static uint32_t last_attempt = 0;
+    if (timer_elapsed32(last_attempt) <= 500) {
+        return;
+    }
+    last_attempt = timer_read32();
+
+    /* Sync all keymap layers */
+    for (uint8_t layer = 0; layer < DYNAMIC_KEYMAP_LAYER_COUNT; layer++) {
+        keymap_layer_sync_t layer_data;
+        layer_data.layer = layer;
+        for (uint8_t row = 0; row < MATRIX_ROWS; row++) {
+            for (uint8_t col = 0; col < MATRIX_COLS; col++) {
+                layer_data.keycodes[row][col] = dynamic_keymap_get_keycode(layer, row, col);
+            }
+        }
+
+        uint8_t ack = 0;
+        if (!transaction_rpc_exec(SPLIT_KEYMAP_SYNC_ID, sizeof(keymap_layer_sync_t), &layer_data, sizeof(ack), &ack) || ack != 1) {
+            return;
+        }
+    }
+
+    /* Send rules */
+    uint8_t ack = 0;
+    if (!transaction_rpc_exec(SPLIT_RULE_LIGHTING_SYNC_ID, sizeof(slave_rules), slave_rules, sizeof(ack), &ack)) {
+        return;
+    }
+    if (ack == 1) {
+        master_sync_complete = true;
+    }
+}
+
+/**
+ * Register split transactions - must be called AFTER split_post_init()
+ */
+void rule_lighting_post_init(void) {
+    transaction_register_rpc(SPLIT_RULE_LIGHTING_SYNC_ID, rule_lighting_slave_handler);
+    transaction_register_rpc(SPLIT_KEYMAP_SYNC_ID, keymap_slave_handler);
+}
+
+#    endif /* SPLIT_KEYBOARD && DYNAMIC_KEYMAP_ENABLE */
+
+/**
+ * Housekeeping task for rule lighting
+ * Handles split sync on master when dynamic keymaps are enabled
+ */
+void rule_lighting_task(void) {
+#    if defined(SPLIT_KEYBOARD) && defined(DYNAMIC_KEYMAP_ENABLE)
+    if (is_keyboard_master()) {
+        rule_lighting_master_sync();
+    }
+#    endif
+}
+
+void rule_lighting_init(void) {
+#    if defined(SPLIT_KEYBOARD) && defined(DYNAMIC_KEYMAP_ENABLE)
+    /* Clear slave rules on init */
+    if (!is_keyboard_master()) {
+        memset(slave_rules, 0, sizeof(slave_rules));
+        return;
+    }
+#    endif
+    nvm_dynamic_keymap_load_rgb_indicators(slave_rules);
+}
+
+#endif /* RGB_MATRIX_ENABLE */

--- a/quantum/rule_lighting.h
+++ b/quantum/rule_lighting.h
@@ -1,0 +1,175 @@
+/* Copyright 2026 Javier Domingo
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <stdint.h>
+#include <stdbool.h>
+
+#ifdef RGB_MATRIX_ENABLE
+
+/* Maximum number of rule lighting entries
+ * This is an internal constant for split sync buffer sizing
+ * Limited to 31 entries max (248 bytes) due to split transaction buffer limit (uint8_t = 255 max)
+ * Users can define any number of rules up to this limit in their keymap
+ */
+#    ifndef RULE_LIGHTING_ENTRIES
+#        define RULE_LIGHTING_ENTRIES 31
+#    endif
+
+/*
+ * Split keyboard configuration for rule lighting
+ * Auto-configures RPC buffer size for split sync
+ * Transaction IDs are defined in transaction_id_define.h
+ *
+ * RPC sync is only needed when DYNAMIC_KEYMAP is enabled (each half has independent EEPROM).
+ * For static keymaps, both halves read rules directly from flash.
+ */
+#    if defined(SPLIT_KEYBOARD) && defined(RULE_LIGHTING_ENABLE) && defined(DYNAMIC_KEYMAP_ENABLE)
+
+/*
+ * RPC buffer size must fit the rules array
+ * Buffer size = 8 bytes per entry * RULE_LIGHTING_ENTRIES
+ */
+#        define _RL_RPC_BUFFER_SIZE (8 * RULE_LIGHTING_ENTRIES)
+
+#        ifndef RPC_M2S_BUFFER_SIZE
+#            define RPC_M2S_BUFFER_SIZE _RL_RPC_BUFFER_SIZE
+#        elif RPC_M2S_BUFFER_SIZE < _RL_RPC_BUFFER_SIZE
+#            undef RPC_M2S_BUFFER_SIZE
+#            define RPC_M2S_BUFFER_SIZE _RL_RPC_BUFFER_SIZE
+#        endif
+
+/* Split state syncing is automatically enabled by builddefs/common_features.mk */
+
+#    endif /* SPLIT_KEYBOARD && RULE_LIGHTING_ENABLE && DYNAMIC_KEYMAP_ENABLE */
+
+/**
+ * Saturation modes (2 bits)
+ */
+typedef enum {
+    RGB_MATRIX_SAT_OFF    = 0b00, // LED off (RGB 0,0,0)
+    RGB_MATRIX_SAT_WHITE  = 0b01, // S=0 (white/grayscale)
+    RGB_MATRIX_SAT_PASTEL = 0b10, // S=128 (soft color)
+    RGB_MATRIX_SAT_PURE   = 0b11, // S=255 (vivid color)
+} rgb_matrix_saturation_t;
+
+#    define RGB_MATRIX_SAT_IS_ON(sat) ((sat) != RGB_MATRIX_SAT_OFF)
+
+/**
+ * RGB Rule Lighting Entry (8 bytes)
+ *
+ * Bit layout:
+ *   Byte 0-1 (condition):
+ *     Bit 0:    layer_enable (0 = any layer, 1 = match layer field)
+ *     Bit 1:    caps_enable (0 = any caps state, 1 = caps must be ON)
+ *     Bits 2-3: reserved
+ *     Bits 4-7: layer (0-15)
+ *     Bits 8-15: mods (modifier mask, 0 = any)
+ *
+ *   Byte 2-3: keycode_start (full 16-bit range)
+ *   Byte 4-5: keycode_end (full 16-bit range, inclusive)
+ *
+ *   Byte 6 (color_idle):
+ *     Bits 0-1: sat_idle
+ *     Bits 2-7: h_idle (6-bit hue, use << 2 for 8-bit)
+ *
+ *   Byte 7 (color_pressed):
+ *     Bits 0-1: sat_pressed
+ *     Bits 2-7: h_pressed (6-bit hue)
+ */
+typedef struct {
+    /* Condition (16 bits) */
+    uint16_t layer_enable : 1;
+    uint16_t caps_enable : 1;
+    uint16_t reserved : 2;
+    uint16_t layer : 4;
+    uint16_t mods : 8;
+
+    /* Keycode range (32 bits) */
+    uint16_t keycode_start;
+    uint16_t keycode_end;
+
+    /* Colors (16 bits) */
+    uint8_t sat_idle : 2;
+    uint8_t h_idle : 6;
+    uint8_t sat_pressed : 2;
+    uint8_t h_pressed : 6;
+
+} __attribute__((packed)) rule_lighting_entry_t;
+
+_Static_assert(sizeof(rule_lighting_entry_t) == 8, "Unexpected size of rule_lighting_entry_t structure");
+
+/**
+ * Initialize the rule lighting system (early init)
+ * Called from rgb_matrix_init() during keyboard_init()
+ */
+void rule_lighting_init(void);
+
+/**
+ * Post-initialization for split keyboard support
+ * Registers RPC handlers - must be called AFTER split_post_init()
+ * Called from keyboard_post_init_kb()
+ */
+void rule_lighting_post_init(void);
+
+/**
+ * Housekeeping task for rule lighting
+ * Handles split keyboard sync on master
+ */
+void rule_lighting_task(void);
+
+/**
+ * Get the rules array
+ * Returns flash array on master, RAM copy on slave
+ */
+const rule_lighting_entry_t *rule_lighting_get_rules(void);
+
+/**
+ * Get keycode for a key position (supports split keyboard sync)
+ * Weak function - keyboards can override with synced keymap support
+ */
+uint16_t get_synced_keycode(uint8_t layer, uint8_t row, uint8_t col);
+
+/**
+ * Convert 6-bit hue to 8-bit
+ */
+#    define RGB_MATRIX_HUE_6TO8(h6) ((h6) << 2)
+
+/**
+ * Convert saturation mode to S value (0-255)
+ */
+static inline uint8_t rgb_matrix_sat_to_value(uint8_t sat_mode) {
+    switch (sat_mode) {
+        case RGB_MATRIX_SAT_OFF:
+            return 0;
+        case RGB_MATRIX_SAT_WHITE:
+            return 0;
+        case RGB_MATRIX_SAT_PASTEL:
+            return 128;
+        case RGB_MATRIX_SAT_PURE:
+            return 255;
+        default:
+            return 0;
+    }
+}
+
+#else /* RGB_MATRIX_ENABLE */
+
+/* Stub when RGB Matrix is disabled */
+#    define RULE_LIGHTING_ENTRIES 0
+
+#endif /* RGB_MATRIX_ENABLE */

--- a/quantum/rule_lighting.h
+++ b/quantum/rule_lighting.h
@@ -19,11 +19,12 @@
 #include <stdint.h>
 #include <stdbool.h>
 
-#ifdef RGB_MATRIX_ENABLE
+#if defined(RGB_MATRIX_ENABLE) && defined(RULE_LIGHTING_ENABLE)
 
 /* Maximum number of rule lighting entries
  * This is an internal constant for split sync buffer sizing
  * Limited to 31 entries max (248 bytes) due to split transaction buffer limit (uint8_t = 255 max)
+ * Can be easily increased but I didn't see the usecase.
  * Users can define any number of rules up to this limit in their keymap
  */
 #    ifndef RULE_LIGHTING_ENTRIES
@@ -38,7 +39,7 @@
  * RPC sync is only needed when DYNAMIC_KEYMAP is enabled (each half has independent EEPROM).
  * For static keymaps, both halves read rules directly from flash.
  */
-#    if defined(SPLIT_KEYBOARD) && defined(RULE_LIGHTING_ENABLE) && defined(DYNAMIC_KEYMAP_ENABLE)
+#    if defined(SPLIT_KEYBOARD) && defined(DYNAMIC_KEYMAP_ENABLE)
 
 /*
  * RPC buffer size must fit the rules array
@@ -55,7 +56,7 @@
 
 /* Split state syncing is automatically enabled by builddefs/common_features.mk */
 
-#    endif /* SPLIT_KEYBOARD && RULE_LIGHTING_ENABLE && DYNAMIC_KEYMAP_ENABLE */
+#    endif /* SPLIT_KEYBOARD && DYNAMIC_KEYMAP_ENABLE */
 
 /**
  * Saturation modes (2 bits)

--- a/quantum/rule_lighting.h
+++ b/quantum/rule_lighting.h
@@ -1,0 +1,221 @@
+/* Copyright 2026 Javier Domingo
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <stdint.h>
+#include <stdbool.h>
+
+#if defined(RGB_MATRIX_ENABLE) && defined(RULE_LIGHTING_ENABLE)
+
+/**
+ * Saturation modes (2 bits)
+ */
+typedef enum {
+    RGB_MATRIX_SAT_OFF    = 0b00, // LED off (RGB 0,0,0)
+    RGB_MATRIX_SAT_WHITE  = 0b01, // S=0 (white/grayscale)
+    RGB_MATRIX_SAT_PASTEL = 0b10, // S=128 (soft color)
+    RGB_MATRIX_SAT_PURE   = 0b11, // S=255 (vivid color)
+} rgb_matrix_saturation_t;
+
+#    define RGB_MATRIX_SAT_IS_ON(sat) ((sat) != RGB_MATRIX_SAT_OFF)
+
+/**
+ * RGB Rule Lighting Entry (8 bytes)
+ *
+ * Bit layout:
+ *   Byte 0-1 (condition):
+ *     Bit 0:    layer_enable (0 = any layer, 1 = match layer field)
+ *     Bit 1:    caps_enable (0 = any caps state, 1 = caps must be ON)
+ *     Bits 2-3: reserved
+ *     Bits 4-7: layer (0-15)
+ *     Bits 8-15: mods (modifier mask, 0 = any)
+ *
+ *   Byte 2-3: keycode_start (full 16-bit range)
+ *   Byte 4-5: keycode_end (full 16-bit range, inclusive)
+ *
+ *   Byte 6 (color_idle):
+ *     Bits 0-1: sat_idle
+ *     Bits 2-7: h_idle (6-bit hue, use << 2 for 8-bit)
+ *
+ *   Byte 7 (color_pressed):
+ *     Bits 0-1: sat_pressed
+ *     Bits 2-7: h_pressed (6-bit hue)
+ */
+typedef struct {
+    /* Condition (16 bits) */
+    uint16_t layer_enable : 1;
+    uint16_t caps_enable : 1;
+    uint16_t reserved : 2;
+    uint16_t layer : 4;
+    uint16_t mods : 8;
+
+    /* Keycode range (32 bits) */
+    uint16_t keycode_start;
+    uint16_t keycode_end;
+
+    /* Colors (16 bits) */
+    uint8_t sat_idle : 2;
+    uint8_t h_idle : 6;
+    uint8_t sat_pressed : 2;
+    uint8_t h_pressed : 6;
+
+} __attribute__((packed)) rule_lighting_entry_t;
+
+_Static_assert(sizeof(rule_lighting_entry_t) == 8, "Unexpected size of rule_lighting_entry_t structure");
+
+/* Default number of RGB indicator entries based on EEPROM size
+ * Matches entry count pattern from other Vial features (tap dance, combos, etc.) */
+#ifndef RULE_LIGHTING_ENTRIES
+    #if TOTAL_EEPROM_BYTE_COUNT > 4000
+        #define RULE_LIGHTING_ENTRIES 32
+    #elif TOTAL_EEPROM_BYTE_COUNT > 2000
+        #define RULE_LIGHTING_ENTRIES 16
+    #elif TOTAL_EEPROM_BYTE_COUNT > 1000
+        #define RULE_LIGHTING_ENTRIES 8
+    #else
+        #define RULE_LIGHTING_ENTRIES 4
+    #endif
+#endif
+
+/*
+ * Split keyboard configuration for rule lighting
+ * Auto-configures RPC buffer size for split sync
+ * Transaction IDs are defined in transaction_id_define.h
+ *
+ * RPC sync is only needed when DYNAMIC_KEYMAP is enabled (each half has independent EEPROM).
+ * For static keymaps, both halves read rules directly from flash.
+ */
+#if defined(SPLIT_KEYBOARD) && defined(DYNAMIC_KEYMAP_ENABLE)
+
+/* Keymap sync data structure (one layer at a time) */
+typedef struct {
+    uint8_t layer;
+    uint16_t keycodes[MATRIX_ROWS][MATRIX_COLS];
+} __attribute__((packed)) keymap_layer_sync_t;
+
+/*
+ * RPC buffer size must fit the larger of:
+ *   - rule_lighting_sync_t: sizeof(rule_lighting_entry_t) * RULE_LIGHTING_ENTRIES
+ *   - keymap_layer_sync_t:  sizeof(keymap_layer_sync_t)
+ */
+#define _RL_SYNC_SIZE (sizeof(rule_lighting_entry_t) * RULE_LIGHTING_ENTRIES)
+#define _KM_SYNC_SIZE (sizeof(keymap_layer_sync_t))
+#define _RL_RPC_BUFFER_SIZE ((_RL_SYNC_SIZE > _KM_SYNC_SIZE) ? _RL_SYNC_SIZE : _KM_SYNC_SIZE)
+
+#    ifndef RPC_M2S_BUFFER_SIZE
+#        define RPC_M2S_BUFFER_SIZE _RL_RPC_BUFFER_SIZE
+#    elif RPC_M2S_BUFFER_SIZE < _RL_RPC_BUFFER_SIZE
+#        undef RPC_M2S_BUFFER_SIZE
+#        define RPC_M2S_BUFFER_SIZE _RL_RPC_BUFFER_SIZE
+#    endif
+
+/* Split state syncing is automatically enabled by builddefs/common_features.mk */
+
+#endif /* SPLIT_KEYBOARD && DYNAMIC_KEYMAP_ENABLE */
+
+/**
+ * Initialize the rule lighting system (early init)
+ * Called from rgb_matrix_init() during keyboard_init()
+ */
+void rule_lighting_init(void);
+
+/**
+ * Post-initialization for split keyboard support
+ * Registers RPC handlers - must be called AFTER split_post_init()
+ * Called from keyboard_post_init_kb()
+ */
+void rule_lighting_post_init(void);
+
+/**
+ * Housekeeping task for rule lighting
+ * Handles split keyboard sync on master
+ */
+void rule_lighting_task(void);
+
+/**
+ * Reset rule lighting to defaults and save to EEPROM
+ */
+void rule_lighting_reset(void);
+
+/**
+ * Load config and rules from EEPROM
+ */
+void rule_lighting_load(void);
+
+/**
+ * Save all rule lighting data to EEPROM
+ */
+void rule_lighting_save(void);
+
+/**
+ * Get the rules array
+ * Returns eeprom/flash array on master, RAM copy on slave
+ */
+const rule_lighting_entry_t *rule_lighting_get_rules(void);
+
+/**
+ * Sync data structure for split keyboard transport
+ */
+typedef struct {
+    rule_lighting_entry_t entries[RULE_LIGHTING_ENTRIES];
+} __attribute__((packed)) rule_lighting_sync_t;
+
+/**
+ * Get pointer to sync data (for split keyboard master)
+ */
+const rule_lighting_sync_t* rule_lighting_get_sync_data(void);
+
+/**
+ * Apply sync data (for split keyboard slave)
+ */
+void rule_lighting_apply_sync_data(const rule_lighting_sync_t *sync_data);
+
+/**
+ * Get keycode for a key position (supports split keyboard sync)
+ * Weak function - keyboards can override with synced keymap support
+ */
+uint16_t get_synced_keycode(uint8_t layer, uint8_t row, uint8_t col);
+
+/**
+ * Convert 6-bit hue to 8-bit
+ */
+#    define RGB_MATRIX_HUE_6TO8(h6) ((h6) << 2)
+
+/**
+ * Convert saturation mode to S value (0-255)
+ */
+static inline uint8_t rgb_matrix_sat_to_value(uint8_t sat_mode) {
+    switch (sat_mode) {
+        case RGB_MATRIX_SAT_OFF:
+            return 0;
+        case RGB_MATRIX_SAT_WHITE:
+            return 0;
+        case RGB_MATRIX_SAT_PASTEL:
+            return 128;
+        case RGB_MATRIX_SAT_PURE:
+            return 255;
+        default:
+            return 0;
+    }
+}
+
+#else /* RGB_MATRIX_ENABLE */
+
+/* Stub when RGB Matrix is disabled */
+#    define RULE_LIGHTING_ENTRIES 0
+
+#endif /* RGB_MATRIX_ENABLE */

--- a/quantum/split_common/transaction_id_define.h
+++ b/quantum/split_common/transaction_id_define.h
@@ -99,12 +99,18 @@ enum serial_transaction_id {
     PUT_ACTIVITY,
 #endif // SPLIT_ACTIVITY_ENABLE
 
-#if defined(SPLIT_TRANSACTION_IDS_KB) || defined(SPLIT_TRANSACTION_IDS_USER)
+#if defined(SPLIT_TRANSACTION_IDS_KB) || defined(SPLIT_TRANSACTION_IDS_USER) || (defined(RULE_LIGHTING_ENABLE) && defined(SPLIT_KEYBOARD))
     PUT_RPC_INFO,
     PUT_RPC_REQ_DATA,
     EXECUTE_RPC,
     GET_RPC_RESP_DATA,
-#endif // defined(SPLIT_TRANSACTION_IDS_KB) || defined(SPLIT_TRANSACTION_IDS_USER)
+#endif // defined(SPLIT_TRANSACTION_IDS_KB) || defined(SPLIT_TRANSACTION_IDS_USER) || (defined(RULE_LIGHTING_ENABLE) && defined(SPLIT_KEYBOARD))
+
+// Rule lighting transaction IDs (must come AFTER GET_RPC_RESP_DATA for validation)
+#if defined(RULE_LIGHTING_ENABLE) && defined(SPLIT_KEYBOARD)
+    SPLIT_RULE_LIGHTING_SYNC_ID,
+    SPLIT_KEYMAP_SYNC_ID,
+#endif // defined(RULE_LIGHTING_ENABLE) && defined(SPLIT_KEYBOARD)
 
 // keyboard-specific
 #ifdef SPLIT_TRANSACTION_IDS_KB

--- a/quantum/split_common/transactions.c
+++ b/quantum/split_common/transactions.c
@@ -85,11 +85,11 @@
 #define transport_read(id, data, length) transport_execute_transaction(id, NULL, 0, data, length)
 #define transport_exec(id) transport_execute_transaction(id, NULL, 0, NULL, 0)
 
-#if defined(SPLIT_TRANSACTION_IDS_KB) || defined(SPLIT_TRANSACTION_IDS_USER)
+#if defined(SPLIT_TRANSACTION_IDS_KB) || defined(SPLIT_TRANSACTION_IDS_USER) || (defined(RULE_LIGHTING_ENABLE) && defined(SPLIT_KEYBOARD))
 // Forward-declare the RPC callback handlers
 void slave_rpc_info_callback(uint8_t initiator2target_buffer_size, const void *initiator2target_buffer, uint8_t target2initiator_buffer_size, void *target2initiator_buffer);
 void slave_rpc_exec_callback(uint8_t initiator2target_buffer_size, const void *initiator2target_buffer, uint8_t target2initiator_buffer_size, void *target2initiator_buffer);
-#endif // defined(SPLIT_TRANSACTION_IDS_KB) || defined(SPLIT_TRANSACTION_IDS_USER)
+#endif // defined(SPLIT_TRANSACTION_IDS_KB) || defined(SPLIT_TRANSACTION_IDS_USER) || (defined(RULE_LIGHTING_ENABLE) && defined(SPLIT_KEYBOARD))
 
 ////////////////////////////////////////////////////
 // Helpers
@@ -943,12 +943,12 @@ split_transaction_desc_t split_transaction_table[NUM_TOTAL_TRANSACTIONS] = {
     TRANSACTIONS_DETECTED_OS_REGISTRATIONS
 // clang-format on
 
-#if defined(SPLIT_TRANSACTION_IDS_KB) || defined(SPLIT_TRANSACTION_IDS_USER)
+#if defined(SPLIT_TRANSACTION_IDS_KB) || defined(SPLIT_TRANSACTION_IDS_USER) || (defined(RULE_LIGHTING_ENABLE) && defined(SPLIT_KEYBOARD))
         [PUT_RPC_INFO]  = trans_initiator2target_initializer_cb(rpc_info, slave_rpc_info_callback),
     [PUT_RPC_REQ_DATA]  = trans_initiator2target_initializer(rpc_m2s_buffer),
     [EXECUTE_RPC]       = trans_initiator2target_initializer_cb(rpc_info.payload.transaction_id, slave_rpc_exec_callback),
     [GET_RPC_RESP_DATA] = trans_target2initiator_initializer(rpc_s2m_buffer),
-#endif // defined(SPLIT_TRANSACTION_IDS_KB) || defined(SPLIT_TRANSACTION_IDS_USER)
+#endif // defined(SPLIT_TRANSACTION_IDS_KB) || defined(SPLIT_TRANSACTION_IDS_USER) || (defined(RULE_LIGHTING_ENABLE) && defined(SPLIT_KEYBOARD))
 };
 
 bool transactions_master(matrix_row_t master_matrix[], matrix_row_t slave_matrix[]) {
@@ -996,7 +996,7 @@ void transactions_slave(matrix_row_t master_matrix[], matrix_row_t slave_matrix[
     TRANSACTIONS_DETECTED_OS_SLAVE();
 }
 
-#if defined(SPLIT_TRANSACTION_IDS_KB) || defined(SPLIT_TRANSACTION_IDS_USER)
+#if defined(SPLIT_TRANSACTION_IDS_KB) || defined(SPLIT_TRANSACTION_IDS_USER) || (defined(RULE_LIGHTING_ENABLE) && defined(SPLIT_KEYBOARD))
 
 void transaction_register_rpc(int8_t transaction_id, slave_callback_t callback) {
     // Prevent invoking RPC on QMK core sync data
@@ -1073,4 +1073,4 @@ void slave_rpc_exec_callback(uint8_t initiator2target_buffer_size, const void *i
     }
 }
 
-#endif // defined(SPLIT_TRANSACTION_IDS_KB) || defined(SPLIT_TRANSACTION_IDS_USER)
+#endif // defined(SPLIT_TRANSACTION_IDS_KB) || defined(SPLIT_TRANSACTION_IDS_USER) || (defined(RULE_LIGHTING_ENABLE) && defined(SPLIT_KEYBOARD))

--- a/quantum/split_common/transport.h
+++ b/quantum/split_common/transport.h
@@ -23,6 +23,11 @@
 #include "action_layer.h"
 #include "matrix.h"
 
+// Allow rule_lighting to set buffer size before defaults
+#if defined(RULE_LIGHTING_ENABLE) && defined(SPLIT_KEYBOARD)
+#    include "rule_lighting.h"
+#endif
+
 #ifndef RPC_M2S_BUFFER_SIZE
 #    define RPC_M2S_BUFFER_SIZE 32
 #endif // RPC_M2S_BUFFER_SIZE
@@ -132,7 +137,7 @@ typedef struct _split_slave_activity_sync_t {
 } split_slave_activity_sync_t;
 #endif // defined(SPLIT_ACTIVITY_ENABLE)
 
-#if defined(SPLIT_TRANSACTION_IDS_KB) || defined(SPLIT_TRANSACTION_IDS_USER)
+#if defined(SPLIT_TRANSACTION_IDS_KB) || defined(SPLIT_TRANSACTION_IDS_USER) || (defined(RULE_LIGHTING_ENABLE) && defined(SPLIT_KEYBOARD))
 typedef struct _rpc_sync_info_t {
     uint8_t checksum;
     struct {
@@ -141,7 +146,7 @@ typedef struct _rpc_sync_info_t {
         uint8_t s2m_length;
     } payload;
 } rpc_sync_info_t;
-#endif // defined(SPLIT_TRANSACTION_IDS_KB) || defined(SPLIT_TRANSACTION_IDS_USER)
+#endif // defined(SPLIT_TRANSACTION_IDS_KB) || defined(SPLIT_TRANSACTION_IDS_USER) || (defined(RULE_LIGHTING_ENABLE) && defined(SPLIT_KEYBOARD))
 
 #if defined(OS_DETECTION_ENABLE) && defined(SPLIT_DETECTED_OS_ENABLE)
 #    include "os_detection.h"
@@ -222,11 +227,11 @@ typedef struct _split_shared_memory_t {
     split_slave_activity_sync_t activity_sync;
 #endif // defined(SPLIT_ACTIVITY_ENABLE)
 
-#if defined(SPLIT_TRANSACTION_IDS_KB) || defined(SPLIT_TRANSACTION_IDS_USER)
+#if defined(SPLIT_TRANSACTION_IDS_KB) || defined(SPLIT_TRANSACTION_IDS_USER) || (defined(RULE_LIGHTING_ENABLE) && defined(SPLIT_KEYBOARD))
     rpc_sync_info_t rpc_info;
     uint8_t         rpc_m2s_buffer[RPC_M2S_BUFFER_SIZE];
     uint8_t         rpc_s2m_buffer[RPC_S2M_BUFFER_SIZE];
-#endif // defined(SPLIT_TRANSACTION_IDS_KB) || defined(SPLIT_TRANSACTION_IDS_USER)
+#endif // defined(SPLIT_TRANSACTION_IDS_KB) || defined(SPLIT_TRANSACTION_IDS_USER) || (defined(RULE_LIGHTING_ENABLE) && defined(SPLIT_KEYBOARD))
 
 #if defined(OS_DETECTION_ENABLE) && defined(SPLIT_DETECTED_OS_ENABLE)
     os_variant_t detected_os;

--- a/quantum/vial.c
+++ b/quantum/vial.c
@@ -62,6 +62,10 @@ static void reload_key_override(void);
 static void reload_alt_repeat_key(void);
 #endif
 
+#ifdef RULE_LIGHTING_ENABLE
+#include "rule_lighting.h"
+#endif
+
 void vial_init(void) {
 #ifdef VIAL_TAP_DANCE_ENABLE
     reload_tap_dance();
@@ -232,6 +236,7 @@ void vial_handle_cmd(uint8_t *msg, uint8_t length) {
                 msg[1] = VIAL_COMBO_ENTRIES;
                 msg[2] = VIAL_KEY_OVERRIDE_ENTRIES;
                 msg[3] = VIAL_ALT_REPEAT_KEY_ENTRIES;
+                msg[4] = RULE_LIGHTING_ENTRIES;
 
                 // The last byte of msg indicates optionally supported features.
                 msg[length - 1] = (0
@@ -317,6 +322,31 @@ void vial_handle_cmd(uint8_t *msg, uint8_t length) {
                 entry.alt_keycode = vial_keycode_firewall(entry.alt_keycode);
                 msg[0] = dynamic_keymap_set_alt_repeat_key(idx, &entry);
                 reload_alt_repeat_key();
+                break;
+            }
+#endif
+#ifdef RULE_LIGHTING_ENABLE
+            case dynamic_rule_lighting_get_entry: {
+                uint8_t idx = msg[3];
+                memset(msg, 0, length);
+                if (idx < RULE_LIGHTING_ENTRIES) {
+                    const rule_lighting_entry_t *rules = rule_lighting_get_rules();
+                    memcpy(&msg[1], &rules[idx], sizeof(rule_lighting_entry_t));
+                    msg[0] = 0;  /* success */
+                } else {
+                    msg[0] = 1;  /* error: index out of bounds */
+                }
+                break;
+            }
+            case dynamic_rule_lighting_set_entry: {
+                uint8_t idx = msg[3];
+                if (idx < RULE_LIGHTING_ENTRIES) {
+                    rule_lighting_entry_t *rules = (rule_lighting_entry_t *)rule_lighting_get_rules();
+                    memcpy(&rules[idx], &msg[4], sizeof(rule_lighting_entry_t));
+                    msg[0] = 0;  /* success */
+                } else {
+                    msg[0] = 1;  /* error: index out of bounds */
+                }
                 break;
             }
 #endif

--- a/quantum/vial.h
+++ b/quantum/vial.h
@@ -60,6 +60,8 @@ enum {
     dynamic_vial_key_override_set = 0x06,
     dynamic_vial_alt_repeat_key_get = 0x07,
     dynamic_vial_alt_repeat_key_set = 0x08,
+    dynamic_rule_lighting_get_entry = 0x09,
+    dynamic_rule_lighting_set_entry = 0x0A,
 };
 
 #define VIAL_MACRO_EXT_TAP 5
@@ -219,4 +221,18 @@ enum {
 #else
 #undef VIAL_ALT_REPEAT_KEY_ENTRIES
 #define VIAL_ALT_REPEAT_KEY_ENTRIES 0
+#endif
+
+
+/* RGB Matrix Rule Lighting effect opt-in feature for per-key colors based on layer/mods/caps/keycode
+ * To enable, add to your config.h:
+ *   #define RULE_LIGHTING_ENABLE
+ * Optionally set entry count (default 31):
+ *   #define RULE_LIGHTING_ENTRIES 16
+ */
+#if defined(RGB_MATRIX_ENABLE) && defined(RULE_LIGHTING_ENABLE)
+#include "rule_lighting.h"
+#else
+#undef RULE_LIGHTING_ENTRIES
+#define RULE_LIGHTING_ENTRIES 0
 #endif

--- a/quantum/vialrgb_effects.inc
+++ b/quantum/vialrgb_effects.inc
@@ -47,6 +47,7 @@ enum {
     VIALRGB_EFFECT_SOLID_MULTISPLASH,
     VIALRGB_EFFECT_PIXEL_RAIN,
     VIALRGB_EFFECT_PIXEL_FRACTAL,
+    VIALRGB_EFFECT_RULE_LIGHTING = 0xFE,  /* Must match GUI's RULE_LIGHTING_EFFECT_IDX */
 };
 
 static const PROGMEM vialrgb_supported_mode_t supported_modes[] = {
@@ -182,5 +183,8 @@ static const PROGMEM vialrgb_supported_mode_t supported_modes[] = {
 #endif
 #ifdef RGB_MATRIX_EFFECT_PIXEL_FRACTAL
     { VIALRGB_EFFECT_PIXEL_FRACTAL, RGB_MATRIX_PIXEL_FRACTAL },
+#endif
+#ifdef RGB_MATRIX_EFFECT_RULE_LIGHTING
+    { VIALRGB_EFFECT_RULE_LIGHTING, RGB_MATRIX_RULE_LIGHTING },
 #endif
 };


### PR DESCRIPTION
I am adding the feature for rule lighting for vial. 

(from the description in the qmk only commit):

rgb_matrix: add rule-based lighting effect
Add a new RGB Matrix effect that allows per-key coloring based on configurable rules. Rules can match against layer state, active modifiers, caps lock state, and keycode ranges. Each rule defines colors for both idle and pressed key states with smooth transitions between them.


This is the delta to support vial on top of https://github.com/qmk/qmk_firmware/pull/25954

The ui changes are at https://github.com/vial-kb/vial-gui/pull/381

