### PR TITLE
Fix qmk.math module to work with python 3.14

### DIFF
--- a/lib/python/qmk/math.py
+++ b/lib/python/qmk/math.py
@@ -23,8 +23,8 @@ def compute(expr):
 
 
 def _eval(node):
-    if isinstance(node, ast.Num):  # <number>
-        return node.n
+    if isinstance(node, ast.Constant) and isinstance(node.value, (int, float)):  # <number>
+        return node.value
     elif isinstance(node, ast.BinOp):  # <left> <operator> <right>
         return operators[type(node.op)](_eval(node.left), _eval(node.right))
     elif isinstance(node, ast.UnaryOp):  # <operator> <operand> e.g., -1

--- a/lib/python/qmk/tests/test_qmk_math.py
+++ b/lib/python/qmk/tests/test_qmk_math.py
@@ -1,0 +1,9 @@
+import qmk.math
+
+from nose2.tools import params
+
+
+@params(('2^6', 4), ('2**6', 64), ('1 + 2*3**(4^5) / (6 + -7)', -5.0))
+def test_compute(expr, expected):
+    result = qmk.math.compute(expr)
+    assert result == expected


### PR DESCRIPTION
What this patch changes:

- `qmk.math` python module: replace its use of `ast.Num` with `ast.Constant`

Why: `ast.Num` was removed in python 3.14

> Deprecated since version 3.8, removed in version 3.14: Previous versions of Python provided the AST classes `ast.Num`, [..], which were deprecated in Python 3.8. These classes were removed in Python 3.14, and their functionality has been replaced with [`ast.Constant`](https://docs.python.org/3/library/ast.html#ast.Constant).  
> https://docs.python.org/3/library/ast.html#ast.AST

qmk-cli's [minimum supported python version is 3.9](github.com/vial-kb/vial-qmk/blob/fcd56b119ea8c60142c9a03e997be5a7acba52b7/lib/python/qmk/cli/__init__v.py#L212), so I think this patch should be fine.

Context: I was running a GHA workflow of a downstream fork that uses the `ghcr.io/qmk/qmk_cli` docker image, and [it failed to run](https://github.com/ento/vial-qmk/actions/runs/21324793751/job/61380056544) due to this class being missing: "AttributeError: module 'ast' has no attribute 'Num'"