### PR TITLE
Update keymap and led indicator of sharkoon skiller sgk50 s2 to streamline to other 96%  ISO keyboards

### DIFF
--- a/keyboards/sharkoon/skiller_sgk50_s2/keymaps/vial/keymap.c
+++ b/keyboards/sharkoon/skiller_sgk50_s2/keymaps/vial/keymap.c
@@ -5,34 +5,14 @@
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 
     [0] = LAYOUT_all(
-        KC_ESC,  KC_F1,   KC_F2,   KC_F3,   KC_F4,   KC_F5,   KC_F6,   KC_F7,   KC_F8,   KC_F9,   KC_F10,  KC_F11,  KC_F12,  KC_PAUS, KC_HOME, KC_END,    KC_PGUP,  KC_PGDN,  KC_DEL,
+        KC_ESC,  KC_F1,   KC_F2,   KC_F3,   KC_F4,   KC_F5,   KC_F6,   KC_F7,   KC_F8,   KC_F9,   KC_F10,  KC_F11,  KC_F12,  KC_DEL,  KC_HOME, KC_END,    KC_PGUP,  KC_PGDN,  KC_PSCR,
         KC_GRV,  KC_1,    KC_2,    KC_3,    KC_4,    KC_5,    KC_6,    KC_7,    KC_8,    KC_9,    KC_0,    KC_MINS, KC_EQL,  KC_BSPC,          KC_NUM,    KC_PSLS,  KC_PAST,  KC_PMNS,
-        KC_TAB,  KC_Q,    KC_W,    KC_E,    KC_R,    KC_T,    KC_Y,    KC_U,    KC_I,    KC_O,    KC_P,    KC_LBRC, KC_RBRC, KC_NONUS_HASH,          KC_P7,     KC_P8,    KC_P9,    KC_PPLS,
+        KC_TAB,  KC_Q,    KC_W,    KC_E,    KC_R,    KC_T,    KC_Y,    KC_U,    KC_I,    KC_O,    KC_P,    KC_LBRC, KC_RBRC, KC_NONUS_HASH,    KC_P7,     KC_P8,    KC_P9,    KC_PPLS,
         KC_CAPS, KC_A,    KC_S,    KC_D,    KC_F,    KC_G,    KC_H,    KC_J,    KC_K,    KC_L,    KC_SCLN, KC_QUOT,          KC_ENT,           KC_P4,     KC_P5,    KC_P6,
         KC_LSFT, KC_NUBS, KC_Z,    KC_X,    KC_C,    KC_V,    KC_B,    KC_N,    KC_M,    KC_COMM, KC_DOT,  KC_SLSH,          KC_RSFT, KC_UP,   KC_P1,     KC_P2,    KC_P3,    KC_PENT,
         KC_LCTL, KC_LGUI, KC_LALT,                            KC_SPC,                             KC_RALT, MO(1),   KC_RCTL, KC_LEFT, KC_DOWN, KC_RGHT,   KC_P0,    KC_PDOT
     ),
 
-};
-
-static const uint8_t numblock[] = {
-    72,
-    73,
-    74,
-    75,
-    44,
-    43,
-    42,
-    41,
-    38,
-    39,
-    40,
-    12,
-    11,
-    10,
-    9,
-    7,
-    8
 };
 
 static const uint8_t arrow[] = {
@@ -48,9 +28,11 @@ bool rgb_matrix_indicators_user() {
     }
 
     if (host_keyboard_led_state().num_lock) {
-        for (uint8_t i = 0; i < sizeof(numblock)/sizeof(numblock[0]); i++) {
-            rgb_matrix_set_color(numblock[i], 30, 30, 0);
-        }
+        rgb_matrix_set_color(72, 30, 30, 0);
+    }
+
+    if (host_keyboard_led_state().caps_lock) {
+        rgb_matrix_set_color(97, 30, 30, 0);
     }
 
     return true;


### PR DESCRIPTION
Change slightly the keymap of the sharkoon skiller sgk50 s2 to streamline to other 96% ISO Keyboards like the Keychron K4

Also make the num_lock and caps_lock indicator led works in same way to highlight the num and caps key
