### PR TITLE
Add RGB_MATRIX_SLEEP definition to config.h

### DIFF
--- a/keyboards/akko/5075/config.h
+++ b/keyboards/akko/5075/config.h
@@ -18,6 +18,7 @@
 
 /* Use 6 dynamic keymap layers */
 #define DYNAMIC_KEYMAP_LAYER_COUNT 6
+#define RGB_MATRIX_SLEEP
 
 /*encoder resolution */
 #define ENCODER_DEFAULT_POS 0x3


### PR DESCRIPTION
Akko 5075: Enable RGB matrix sleep

Added the RGB_MATRIX_SLEEP definition to config.h. This ensures that RGB LEDs turn off automatically when the host computer enters sleep mode or shuts down, preventing unnecessary power consumption and LED wear when the USB ports provide standby power.