### PR TITLE
Support Dictation (macOS)

### DIFF
--- a/data/constants/keycodes/keycodes_0.0.2_basic.hjson
+++ b/data/constants/keycodes/keycodes_0.0.2_basic.hjson
@@ -15,6 +15,14 @@
             "aliases": [
                 "KC_LPAD"
             ]
+        },
+        "0x00C3": {
+            "group": "media",
+            "key": "KC_DICTATION",
+            "label": "Start Dictation (macOS)",
+            "aliases": [
+                "KC_DICT"
+            ]
         }
     }
 }

--- a/quantum/keycodes.h
+++ b/quantum/keycodes.h
@@ -295,6 +295,7 @@ enum qk_keycode_defines {
     KC_ASSISTANT = 0x00C0,
     KC_MISSION_CONTROL = 0x00C1,
     KC_LAUNCHPAD = 0x00C2,
+    KC_DICTATION = 0x00C3,
     QK_MOUSE_CURSOR_UP = 0x00CD,
     QK_MOUSE_CURSOR_DOWN = 0x00CE,
     QK_MOUSE_CURSOR_LEFT = 0x00CF,
@@ -951,6 +952,7 @@ enum qk_keycode_defines {
     KC_ASST    = KC_ASSISTANT,
     KC_MCTL    = KC_MISSION_CONTROL,
     KC_LPAD    = KC_LAUNCHPAD,
+    KC_DICT    = KC_DICTATION,
     MS_UP      = QK_MOUSE_CURSOR_UP,
     MS_DOWN    = QK_MOUSE_CURSOR_DOWN,
     MS_LEFT    = QK_MOUSE_CURSOR_LEFT,
@@ -1497,7 +1499,7 @@ enum qk_keycode_defines {
 #define IS_INTERNAL_KEYCODE(code) ((code) >= KC_NO && (code) <= KC_TRANSPARENT)
 #define IS_BASIC_KEYCODE(code) ((code) >= KC_A && (code) <= KC_EXSEL)
 #define IS_SYSTEM_KEYCODE(code) ((code) >= KC_SYSTEM_POWER && (code) <= KC_SYSTEM_WAKE)
-#define IS_CONSUMER_KEYCODE(code) ((code) >= KC_AUDIO_MUTE && (code) <= KC_LAUNCHPAD)
+#define IS_CONSUMER_KEYCODE(code) ((code) >= KC_AUDIO_MUTE && (code) <= KC_DICTATION)
 #define IS_MOUSE_KEYCODE(code) ((code) >= QK_MOUSE_CURSOR_UP && (code) <= QK_MOUSE_ACCELERATION_2)
 #define IS_MODIFIER_KEYCODE(code) ((code) >= KC_LEFT_CTRL && (code) <= KC_RIGHT_GUI)
 #define IS_SWAP_HANDS_KEYCODE(code) ((code) >= QK_SWAP_HANDS_TOGGLE && (code) <= QK_SWAP_HANDS_ONE_SHOT)
@@ -1523,7 +1525,7 @@ enum qk_keycode_defines {
 #define INTERNAL_KEYCODE_RANGE              KC_NO ... KC_TRANSPARENT
 #define BASIC_KEYCODE_RANGE                 KC_A ... KC_EXSEL
 #define SYSTEM_KEYCODE_RANGE                KC_SYSTEM_POWER ... KC_SYSTEM_WAKE
-#define CONSUMER_KEYCODE_RANGE              KC_AUDIO_MUTE ... KC_LAUNCHPAD
+#define CONSUMER_KEYCODE_RANGE              KC_AUDIO_MUTE ... KC_DICTATION
 #define MOUSE_KEYCODE_RANGE                 QK_MOUSE_CURSOR_UP ... QK_MOUSE_ACCELERATION_2
 #define MODIFIER_KEYCODE_RANGE              KC_LEFT_CTRL ... KC_RIGHT_GUI
 #define SWAP_HANDS_KEYCODE_RANGE            QK_SWAP_HANDS_TOGGLE ... QK_SWAP_HANDS_ONE_SHOT

--- a/tmk_core/protocol/report.h
+++ b/tmk_core/protocol/report.h
@@ -77,6 +77,7 @@ enum consumer_usages {
     TRANSPORT_RANDOM_PLAY  = 0x0B9,
     TRANSPORT_STOP_EJECT   = 0x0CC,
     TRANSPORT_PLAY_PAUSE   = 0x0CD,
+    VOICE_COMMAND          = 0x0CF, // macOS Sonoma+ Dictation trigger
     // 15.9.1 Audio Controls - Volume
     AUDIO_MUTE     = 0x0E2,
     AUDIO_VOL_UP   = 0x0E9,
@@ -335,6 +336,8 @@ static inline uint16_t KEYCODE2CONSUMER(uint8_t key) {
             return AC_DESKTOP_SHOW_ALL_WINDOWS;
         case KC_LAUNCHPAD:
             return AC_SOFT_KEY_LEFT;
+        case KC_DICTATION:
+            return VOICE_COMMAND;
         default:
             return 0;
     }


### PR DESCRIPTION
Added key handling for macOS Dictation

I don't know if I'm doing this right, let me know or ignore completely if not :)

(it works for me ;) )

KC_DICTATION with alias KC_DICT and virtual keycode 0xC3

Unfortunately, I don't not know what changes to make so that Vial.rocks actually shows KC_DICT.