### PR TITLE
Initialize Quick Tap Term, NKRO, and Grave Escape QMK settings according to config.h options.

### DIFF
--- a/quantum/qmk_settings.c
+++ b/quantum/qmk_settings.c
@@ -188,7 +188,10 @@ void qmk_settings_init(void) {
 }
 
 void qmk_settings_reset(void) {
-    QS.grave_esc_override = 0;
+    QS.grave_esc_override = (GRAVE_ESC_ALT_OVERRIDE_Defined << 0)
+                          | (GRAVE_ESC_CTRL_OVERRIDE_Defined << 1)
+                          | (GRAVE_ESC_GUI_OVERRIDE_Defined << 2)
+                          | (GRAVE_ESC_SHIFT_OVERRIDE_Defined << 3);
     QS.auto_shift = 0;
     QS.auto_shift_timeout = AUTO_SHIFT_TIMEOUT;
     QS.osk_tap_toggle = ONESHOT_TAP_TOGGLE;
@@ -209,7 +212,7 @@ void qmk_settings_reset(void) {
     QS.combo_term = COMBO_TERM;
     QS.tapping_term = TAPPING_TERM;
     QS.tapping_v2 = 0;
-    QS.quick_tap_term = TAPPING_TERM;
+    QS.quick_tap_term = QUICK_TAP_TERM;
     QS.tap_code_delay = TAP_CODE_DELAY;
     QS.tap_hold_caps_delay = TAP_HOLD_CAPS_DELAY;
     QS.tapping_toggle = TAPPING_TOGGLE;
@@ -220,7 +223,8 @@ void qmk_settings_reset(void) {
     /* must call clear_keyboard for the NKRO setting to not cause stuck keys */
     clear_keyboard();
     keymap_config.raw = 0;
-    keymap_config.oneshot_enable = 1;
+    keymap_config.nkro = NKRO_DEFAULT_ON;
+    keymap_config.oneshot_enable = true;
     eeconfig_update_keymap(&keymap_config);
 
     /* to trigger all callbacks */

--- a/quantum/qmk_settings.h
+++ b/quantum/qmk_settings.h
@@ -96,6 +96,13 @@
 #define ONESHOT_TIMEOUT 5000
 #endif
 
+/* ========================================================================== */
+/* NKRO                                                                       */
+/* ========================================================================== */
+#ifndef NKRO_DEFAULT_ON
+#    define NKRO_DEFAULT_ON false
+#endif
+
 #ifdef QMK_SETTINGS
 /* dynamic settings framework is enabled */
 


### PR DESCRIPTION
This PR makes the initial settings of Quick Tap Term, NKRO, and Grave Escape configurable, following the usual QMK config.h defines for these options.


## Description

After freshly flashing firmware, it would be intuitive if Vial resets the QMK settings struct in such way that fields initialize according to the usual QMK config options. This way, it is predictable how to configure these initial settings in a custom Vial build, simply by defining them in `config.h` in the same way as done in mainline QMK.

For the most part, QMK settings does work this way, but there are a few gaps as [noted in this reddit thread](https://www.reddit.com/r/olkb/s/Z4A5rAJoe8). This PR attempts to improve that. The `qmk_settings_reset()` function is modified to initialize fields to follow these QMK config options:

```.c
// Interval in ms for Quick Tap.
#define QUICK_TAP_TERM <number>  

// Configure NKRO to default to on.
#define NKRO_DEFAULT_ON true

// Grave Escape options:
#define GRAVE_ESC_ALT_OVERRIDE   // Grave Escape always sends Escape if Alt is pressed.
#define GRAVE_ESC_CTRL_OVERRIDE  // Grave Escape always sends Escape if Control is pressed.
#define GRAVE_ESC_GUI_OVERRIDE   // Grave Escape always sends Escape if GUI is pressed.
#define GRAVE_ESC_SHIFT_OVERRIDE // Grave Escape always sends Escape if Shift is pressed.
```

I have tested these changes on a keyboard to verify these config options appear as the initial settings after flashing.