### PR TITLE
Fix alps64 crashing

### DIFF
--- a/keyboards/alps64/keymaps/vial/rules.mk
+++ b/keyboards/alps64/keymaps/vial/rules.mk
@@ -3,8 +3,15 @@ VIAL_ENABLE = yes
 LTO_ENABLE = yes
 CONSOLE_ENABLE = no
 COMMAND_ENABLE = no
-TAP_DANCE_ENABLE = no
 MIDI_ENABLE = no
+
+# The atmega32u2 only has 1kB of SRAM. The Vial defaults (combos, key overrides,
+# tap dance, QMK settings + auto shift) leave barely 100 bytes of stack, which the
+# USB/keyboard call chain blows straight through into .bss. Keep them off.
+TAP_DANCE_ENABLE = no
+COMBO_ENABLE = no
+KEY_OVERRIDE_ENABLE = no
+QMK_SETTINGS = no
 
 CAPS_WORD_ENABLE = no
 LAYER_LOCK_ENABLE = no


### PR DESCRIPTION
When I flash the alps64:vial build onto my alps64, it was outputting random characters without typing. The ATmega32u2 only has 1KB of SRAM and its stack only has 104 bytes. During runtime the stack can easily overflow and cause random behaviors. Disabling tap dance, key combo, key override and qmk settings grows the available stack space to 645 bytes.

I tested on my alps64 and the keyboard functions as expected and I was able to update key map using Vial.